### PR TITLE
Working Core RPC and Transactional Store Commit

### DIFF
--- a/cmd/gigawallet/main.go
+++ b/cmd/gigawallet/main.go
@@ -26,7 +26,7 @@ func main() {
 		panic(fmt.Sprintf("bad config: missing dogecoind.%s.host", conf.Gigawallet.Dogecoind))
 	}
 
-	rpc, err := dogecoin.NewL1Libdogecoin(conf)
+	rpc, err := dogecoin.NewL1Libdogecoin(conf, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -44,8 +44,12 @@ func main() {
 	// Configure loggers
 	messages.SetupLoggers(c, bus, conf)
 
-	// Setup the L1 interface to Core
-	l1, err := dogecoin.NewL1Libdogecoin(conf)
+	// Set up the L1 interface to Core
+	l1_core, err := core.NewDogecoinCoreRPC(conf)
+	if err != nil {
+		panic(err)
+	}
+	l1, err := dogecoin.NewL1Libdogecoin(conf, l1_core)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/gigawallet/main.go
+++ b/cmd/gigawallet/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	giga "github.com/dogecoinfoundation/gigawallet/pkg"
@@ -19,12 +18,6 @@ func main() {
 		os.Exit(1)
 	}
 	conf := giga.LoadConfig(os.Args[1])
-	if len(conf.Gigawallet.Dogecoind) < 1 {
-		panic("bad config: missing gigawallet.dogecoind")
-	}
-	if len(conf.Dogecoind[conf.Gigawallet.Dogecoind].Host) < 1 {
-		panic(fmt.Sprintf("bad config: missing dogecoind.%s.host", conf.Gigawallet.Dogecoind))
-	}
 
 	rpc, err := dogecoin.NewL1Libdogecoin(conf, nil)
 	if err != nil {

--- a/cmd/gigawallet/main.go
+++ b/cmd/gigawallet/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	giga "github.com/dogecoinfoundation/gigawallet/pkg"
@@ -55,7 +56,7 @@ func main() {
 	defer store.Close()
 
 	// Start the TxnConfirmer service
-	cf, err := broker.NewTxnConfirmer(conf)
+	cf, err := broker.NewTxnConfirmer(conf, l1)
 	if err != nil {
 		panic(err)
 	}

--- a/devconf.toml
+++ b/devconf.toml
@@ -4,7 +4,7 @@
   bind = "localhost"  # avoids macOS firewall confirmation!
 
 [gigawallet]
-  dogecoind = "testnet"  # which dogecoind to connect to
+  dogecoind = "mainnet"  # which dogecoind to connect to
 
 [dogecoind.testnet]
   host    = "localhost"
@@ -16,6 +16,7 @@
 [dogecoind.mainnet]
   host    = "localhost"
   zmqport = 28332
+  rpchost = "127.0.0.1"
   rpcport = 22555
   rpcpass = "gigawallet"
   rpcuser = "gigawallet"

--- a/pkg/broker/confirmer.go
+++ b/pkg/broker/confirmer.go
@@ -2,12 +2,15 @@ package broker
 
 import (
 	"context"
-	"strings"
+	"fmt"
+	"time"
 
 	giga "github.com/dogecoinfoundation/gigawallet/pkg"
+	"github.com/shopspring/decimal"
 )
 
 type TxnConfirmer struct {
+	l1                  giga.L1
 	ReceiveFromNode     chan giga.NodeEvent
 	ReceiveFromBroker   chan giga.BrokerEvent
 	listeners           []chan<- giga.BrokerEvent
@@ -20,8 +23,12 @@ type TxnConfirmer struct {
  * Confirmer receives txn_ids or invoice_ids from Store ???
  * Confirmer sends
  */
-func NewTxnConfirmer(conf giga.Config) (*TxnConfirmer, error) {
-	result := &TxnConfirmer{ReceiveFromNode: make(chan giga.NodeEvent, 100), confirmationsNeeded: conf.Gigawallet.ConfirmationsNeeded}
+func NewTxnConfirmer(conf giga.Config, l1 giga.L1) (*TxnConfirmer, error) {
+	result := &TxnConfirmer{
+		l1:                  l1,
+		ReceiveFromNode:     make(chan giga.NodeEvent, 1000),
+		confirmationsNeeded: conf.Gigawallet.ConfirmationsNeeded,
+	}
 	return result, nil
 }
 
@@ -55,23 +62,24 @@ func (c *TxnConfirmer) Run(started, stopped chan bool, stop chan context.Context
 						rawTxToInfo[e.Data] = &txInfo{id: e.ID, foundInBlock: false, confirmations: 0}
 					}
 				case giga.Block:
-					for raw, info := range rawTxToInfo {
-						if !info.foundInBlock {
-							if strings.Contains(e.Data, raw) {
-								info.foundInBlock = true // next if statement will increment confirmations
-							}
-						}
-						if info.foundInBlock {
-							info.confirmations++
-						}
-						if info.confirmations >= c.confirmationsNeeded {
-							e := giga.BrokerEvent{Type: giga.InvoiceConfirmed, ID: info.id}
-							for _, ch := range c.listeners {
-								ch <- e
-							}
-							delete(rawTxToInfo, raw)
-						}
-					}
+					c.processBlock(e.ID)
+					// for raw, info := range rawTxToInfo {
+					// 	if !info.foundInBlock {
+					// 		if strings.Contains(e.Data, raw) {
+					// 			info.foundInBlock = true // next if statement will increment confirmations
+					// 		}
+					// 	}
+					// 	if info.foundInBlock {
+					// 		info.confirmations++
+					// 	}
+					// 	if info.confirmations >= c.confirmationsNeeded {
+					// 		e := giga.BrokerEvent{Type: giga.InvoiceConfirmed, ID: info.id}
+					// 		for _, ch := range c.listeners {
+					// 			ch <- e
+					// 		}
+					// 		delete(rawTxToInfo, raw)
+					// 	}
+					// }
 				}
 			case <-stop:
 				stopped <- true
@@ -81,4 +89,55 @@ func (c *TxnConfirmer) Run(started, stopped chan bool, stop chan context.Context
 	}()
 
 	return nil
+}
+
+// received a block_id (new block) from the network.
+// fetch and decode the block from Core.
+func (c *TxnConfirmer) processBlock(blockHash string) {
+	block := c.fetchBlock(blockHash)
+
+	// make a Set of all UTXOs in Transaction VOuts
+	UTXOs := make(map[string]decimal.Decimal) // Set
+	for _, txn_id := range block.Tx {
+		txn := c.fetchTransaction(txn_id)
+		for _, vout := range txn.VOut {
+			if vout.Value.IsPositive() { // greater than zero
+				for _, addr := range vout.ScriptPubKey.Addresses {
+					if val, ok := UTXOs[addr]; ok {
+						UTXOs[addr] = val.Add(vout.Value)
+					} else {
+						UTXOs[addr] = vout.Value
+					}
+				}
+			}
+		}
+	}
+
+	fmt.Printf("Block=> hash %s contains %d UTXOs: %v\n", blockHash, len(block.Tx), UTXOs)
+}
+
+func (c *TxnConfirmer) fetchBlock(blockHash string) giga.RpcBlock {
+	for {
+		block, err := c.l1.GetBlock(blockHash)
+		if err != nil {
+			// back-pressure: we need to try again later.
+			fmt.Printf("[!] GetBlock: fetching '%s' : %v\n", blockHash, err)
+			time.Sleep(1 * time.Second)
+		} else {
+			return block
+		}
+	}
+}
+
+func (c *TxnConfirmer) fetchTransaction(txnHash string) giga.RawTxn {
+	for {
+		txn, err := c.l1.GetTransaction(txnHash)
+		if err != nil {
+			// back-pressure: we need to try again later.
+			fmt.Printf("[!] GetTransaction: fetching '%s' : %v\n", txnHash, err)
+			time.Sleep(1 * time.Second)
+		} else {
+			return txn
+		}
+	}
 }

--- a/pkg/broker/payments.go
+++ b/pkg/broker/payments.go
@@ -39,7 +39,11 @@ func (p PaymentBroker) Run(started, stopped chan bool, stop chan context.Context
 					p.sendEvent(giga.BrokerEvent{Type: giga.NewInvoice, ID: e.ID})
 				case giga.InvoiceConfirmed:
 					// from Confirmer
-					err := p.store.MarkInvoiceAsPaid(giga.Address(e.ID))
+					err := p.store.Commit([]any{
+						giga.MarkInvoiceAsPaid{
+							InvoiceID: giga.Address(e.ID),
+						},
+					})
 					if err != nil {
 						log.Println("error marking invoice with id", e.ID, "as paid:", err)
 						return

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,6 +1,8 @@
 package giga
 
 import (
+	"fmt"
+
 	"github.com/jinzhu/configor"
 )
 
@@ -36,10 +38,20 @@ type Config struct {
 
 	// info for connecting to dogecoin-core daemon
 	Dogecoind map[string]NodeConfig
+	// currently active NodeConfig
+	Core NodeConfig
 }
 
 func LoadConfig(confPath string) Config {
 	c := Config{Dogecoind: make(map[string]NodeConfig)}
 	configor.Load(&c, confPath)
+	// config load never fails, so validate:
+	if len(c.Gigawallet.Dogecoind) < 1 {
+		panic("bad config: missing gigawallet.dogecoind (select active network)")
+	}
+	c.Core = c.Dogecoind[c.Gigawallet.Dogecoind]
+	if len(c.Core.Host) < 1 {
+		panic(fmt.Sprintf("bad config: missing dogecoind.%s.host", c.Gigawallet.Dogecoind))
+	}
 	return c
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -7,6 +7,7 @@ import (
 type NodeConfig struct {
 	Host    string `default:"localhost"`
 	ZMQPort int    `default:"28332"`
+	RPCHost string `default:"127.0.0.1"`
 	RPCPort int    `default:"44555"`
 	RPCPass string `default:"gigawallet"`
 	RPCUser string `default:"gigawallet"`

--- a/pkg/core/receiver.go
+++ b/pkg/core/receiver.go
@@ -14,6 +14,9 @@ import (
 // interface guard ensures ZMQEmitter implements giga.NodeEmitter
 var _ giga.NodeEmitter = &CoreReceiver{}
 
+// CoreReceiver receives ZMQ messages from Dogecoin Core.
+// CAUTION: the protocol is not authenticated!
+// CAUTION: subscribers MUST validate the received data since it may be out of date, incomplete or even invalid (fake)
 type CoreReceiver struct {
 	bus         giga.MessageBus
 	sock        *zmq4.Socket

--- a/pkg/core/receiver.go
+++ b/pkg/core/receiver.go
@@ -48,8 +48,7 @@ func (z CoreReceiver) Run(started, stopped chan bool, stop chan context.Context)
 	if err != nil {
 		return err
 	}
-	// err = subscribeAll(sock, "hashtx", "rawtx", "rawblock")
-	err = sock.SetSubscribe("") // enable all messages.
+	err = subscribeAll(sock, "hashtx", "rawtx", "hashblock")
 	if err != nil {
 		return err
 	}
@@ -104,11 +103,7 @@ func (z CoreReceiver) Run(started, stopped chan bool, stop chan context.Context)
 			case "hashblock":
 				id := toHex(msg[1])
 				fmt.Printf("ZMQ=> Block id=%s\n", id)
-				z.notify(giga.TX, id, "")
-			case "rawblock":
-				block := toHex(msg[1])
-				fmt.Printf("ZMQ=> Block %s\n", block)
-				z.notify(giga.Block, "", block)
+				z.notify(giga.Block, id, "")
 			default:
 				fmt.Printf("ZMQ=> %s ??\n", tag)
 			}
@@ -131,12 +126,12 @@ func toHex(b []byte) string {
 	return hex.EncodeToString(b)
 }
 
-// func subscribeAll(sock *zmq4.Socket, topics ...string) error {
-// 	for _, topic := range topics {
-// 		err := sock.SetSubscribe(topic)
-// 		if err != nil {
-// 			return err
-// 		}
-// 	}
-// 	return nil
-// }
+func subscribeAll(sock *zmq4.Socket, topics ...string) error {
+	for _, topic := range topics {
+		err := sock.SetSubscribe(topic)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/core/receiver.go
+++ b/pkg/core/receiver.go
@@ -128,12 +128,12 @@ func toHex(b []byte) string {
 	return hex.EncodeToString(b)
 }
 
-func subscribeAll(sock *zmq4.Socket, topics ...string) error {
-	for _, topic := range topics {
-		err := sock.SetSubscribe(topic)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
+// func subscribeAll(sock *zmq4.Socket, topics ...string) error {
+// 	for _, topic := range topics {
+// 		err := sock.SetSubscribe(topic)
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+// 	return nil
+// }

--- a/pkg/core/receiver.go
+++ b/pkg/core/receiver.go
@@ -98,11 +98,12 @@ func (z CoreReceiver) Run(started, stopped chan bool, stop chan context.Context)
 					panic(fmt.Sprintf("zmq error: expected rawtx after hashtx %s", id))
 				}
 				rawtx := toHex(msg[1])
-				fmt.Printf("ZMQ=> TX id=%s rawtx=%s\n", id, rawtx)
+				// fmt.Printf("ZMQ=> TX id=%s rawtx=%s\n", id, rawtx)
+				fmt.Printf("ZMQ=> TX id=%s\n", id)
 				z.notify(giga.TX, id, rawtx)
 			case "hashblock":
 				id := toHex(msg[1])
-				fmt.Printf("ZMQ=> Block id=%s\n", id)
+				fmt.Printf("ZMQ=> BLOCK id=%s\n", id)
 				z.notify(giga.Block, id, "")
 			default:
 				fmt.Printf("ZMQ=> %s ??\n", tag)

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -30,21 +30,36 @@ type L1CoreRPC struct {
 }
 
 func (l L1CoreRPC) MakeAddress() (giga.Address, giga.Privkey, error) {
-	// res := map[string]struct{}{}
-	res := ""
-	err := l.client.Call("getrpcinfo", nil, &res)
-	fmt.Println(res, err)
-	return "foo", "bar", nil
+	return "", "", fmt.Errorf("not implemented")
 }
 
 func (l L1CoreRPC) MakeChildAddress(privkey giga.Privkey, addressIndex uint32, isInternal bool) (giga.Address, error) {
-	return "foo", nil
+	return "", fmt.Errorf("not implemented")
 }
 
-func (l L1CoreRPC) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.Txn, error) {
-	return giga.Txn{}, fmt.Errorf("not implemented")
+func (l L1CoreRPC) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.NewTxn, error) {
+	return giga.NewTxn{}, fmt.Errorf("not implemented")
 }
 
-func (l L1CoreRPC) Send(txn giga.Txn) error {
-	return nil
+type DecodeRawTransactionArgs struct {
+	Hexstring string `json:"hexstring"`
+}
+
+type DecodeRawTransactionResponse struct {
+	// TODO: dogecoin core response
+}
+
+func (l L1CoreRPC) DecodeTransaction(txn_hex string) (txn giga.DecodedTxn, err error) {
+	args := DecodeRawTransactionArgs{Hexstring: txn_hex}
+	res := DecodeRawTransactionResponse{}
+	err = l.client.Call("decoderawtransaction", &args, &res)
+	if err != nil {
+		return
+	}
+	// TODO: populate 'txn' from 'res'
+	return
+}
+
+func (l L1CoreRPC) Send(txn giga.NewTxn) error {
+	return fmt.Errorf("not implemented")
 }

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -42,21 +42,12 @@ func (l L1CoreRPC) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, pa
 }
 
 type DecodeRawTransactionArgs struct {
-	Hexstring string `json:"hexstring"`
+	Hex string `json:"hexstring"`
 }
 
-type DecodeRawTransactionResponse struct {
-	// TODO: dogecoin core response
-}
-
-func (l L1CoreRPC) DecodeTransaction(txn_hex string) (txn giga.DecodedTxn, err error) {
-	args := DecodeRawTransactionArgs{Hexstring: txn_hex}
-	res := DecodeRawTransactionResponse{}
-	err = l.client.Call("decoderawtransaction", &args, &res)
-	if err != nil {
-		return
-	}
-	// TODO: populate 'txn' from 'res'
+func (l L1CoreRPC) DecodeTransaction(txn_hex string) (txn giga.RawTxn, err error) {
+	args := DecodeRawTransactionArgs{Hex: txn_hex}
+	err = l.client.Call("decoderawtransaction", &args, &txn)
 	return
 }
 

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -26,7 +26,7 @@ type L1CoreRPC struct {
 	url  string
 	user string
 	pass string
-	id   uint64
+	id   *uint64
 }
 
 type rpcRequest struct {
@@ -40,13 +40,13 @@ type rpcResponse struct {
 	Error  any              `json:"error"`
 }
 
-func (l *L1CoreRPC) request(method string, params []any, result any) error {
+func (l L1CoreRPC) request(method string, params []any, result any) error {
 	body := rpcRequest{
 		Method: method,
 		Params: params,
-		Id:     l.id,
+		Id:     *l.id,
 	}
-	l.id += 1 // each request should use a unique ID
+	*l.id += 1 // each request should use a unique ID
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("json-rpc marshal request: %v", err)

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -110,6 +110,15 @@ func (l L1CoreRPC) DecodeTransaction(txn_hex string) (txn giga.RawTxn, err error
 	return
 }
 
+func (l L1CoreRPC) GetBlock(blockHash string, decodeTxns bool) (txn giga.RpcBlock, err error) {
+	verbosity := 1 // returns an Object with information about block ‘hash’.
+	if decodeTxns {
+		verbosity = 2 // returns an Object with information about block ‘hash’ and information about each transaction.
+	}
+	err = l.request("getblock", []any{blockHash, verbosity}, &txn)
+	return
+}
+
 func (l L1CoreRPC) Send(txn giga.NewTxn) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -88,7 +88,7 @@ func (l L1CoreRPC) request(method string, params []any, result any) error {
 	}
 	err = json.Unmarshal(*rpcres.Result, result)
 	if err != nil {
-		return fmt.Errorf("json-rpc unmarshal result: %v", err)
+		return fmt.Errorf("json-rpc unmarshal result: %v | %v", err, string(*rpcres.Result))
 	}
 	return nil
 }
@@ -110,12 +110,15 @@ func (l L1CoreRPC) DecodeTransaction(txn_hex string) (txn giga.RawTxn, err error
 	return
 }
 
-func (l L1CoreRPC) GetBlock(blockHash string, decodeTxns bool) (txn giga.RpcBlock, err error) {
-	verbosity := 1 // returns an Object with information about block ‘hash’.
-	if decodeTxns {
-		verbosity = 2 // returns an Object with information about block ‘hash’ and information about each transaction.
-	}
-	err = l.request("getblock", []any{blockHash, verbosity}, &txn)
+func (l L1CoreRPC) GetBlock(blockHash string) (txn giga.RpcBlock, err error) {
+	decode := true // to get back JSON rather than HEX
+	err = l.request("getblock", []any{blockHash, decode}, &txn)
+	return
+}
+
+func (l L1CoreRPC) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
+	decode := true // to get back JSON rather than HEX
+	err = l.request("getrawtransaction", []any{txnHash, decode}, &txn)
 	return
 }
 

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -15,10 +15,11 @@ var _ giga.L1 = L1CoreRPC{}
 
 // NewDogecoinCoreRPC returns a giga.L1 implementor that uses dogecoin-core's RPC
 func NewDogecoinCoreRPC(config giga.Config) (L1CoreRPC, error) {
-	addr := fmt.Sprintf("http://%s:%d", config.Dogecoind[config.Gigawallet.Dogecoind].RPCHost, config.Dogecoind[config.Gigawallet.Dogecoind].RPCPort)
-	user := config.Dogecoind[config.Gigawallet.Dogecoind].RPCUser
-	pass := config.Dogecoind[config.Gigawallet.Dogecoind].RPCPass
-	return L1CoreRPC{addr, user, pass, 1}, nil
+	addr := fmt.Sprintf("http://%s:%d", config.Core.RPCHost, config.Core.RPCPort)
+	user := config.Core.RPCUser
+	pass := config.Core.RPCPass
+	var id uint64 = 1
+	return L1CoreRPC{addr, user, pass, &id}, nil
 }
 
 type L1CoreRPC struct {

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -1,9 +1,11 @@
 package core
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"net/rpc"
-	"net/rpc/jsonrpc"
+	"io"
+	"net/http"
 
 	giga "github.com/dogecoinfoundation/gigawallet/pkg"
 )
@@ -13,20 +15,81 @@ var _ giga.L1 = L1CoreRPC{}
 
 // NewDogecoinCoreRPC returns a giga.L1 implementor that uses dogecoin-core's RPC
 func NewDogecoinCoreRPC(config giga.Config) (L1CoreRPC, error) {
-	// Connect to the dogecoin daemon
-	addr := fmt.Sprintf("%s:%d", config.Dogecoind[config.Gigawallet.Dogecoind].Host, config.Dogecoind[config.Gigawallet.Dogecoind].RPCPort)
-	fmt.Println("Dialing:", addr)
-	c, err := jsonrpc.Dial("tcp", addr)
-	if err != nil {
-		return L1CoreRPC{}, err
-	}
-	fmt.Println("Dialed")
-
-	return L1CoreRPC{c}, nil
+	addr := fmt.Sprintf("http://%s:%d", config.Dogecoind[config.Gigawallet.Dogecoind].RPCHost, config.Dogecoind[config.Gigawallet.Dogecoind].RPCPort)
+	user := config.Dogecoind[config.Gigawallet.Dogecoind].RPCUser
+	pass := config.Dogecoind[config.Gigawallet.Dogecoind].RPCPass
+	return L1CoreRPC{addr, user, pass, 1}, nil
 }
 
 type L1CoreRPC struct {
-	client *rpc.Client
+	url  string
+	user string
+	pass string
+	id   uint64
+}
+
+type rpcRequest struct {
+	Method string `json:"method"`
+	Params []any  `json:"params"`
+	Id     uint64 `json:"id"`
+}
+type rpcResponse struct {
+	Id     uint64           `json:"id"`
+	Result *json.RawMessage `json:"result"`
+	Error  any              `json:"error"`
+}
+
+func (l *L1CoreRPC) request(method string, params []any, result any) error {
+	body := rpcRequest{
+		Method: method,
+		Params: params,
+		Id:     l.id,
+	}
+	l.id += 1 // each request should use a unique ID
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("json-rpc marshal request: %v", err)
+	}
+	req, err := http.NewRequest("POST", l.url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("json-rpc request: %v", err)
+	}
+	req.SetBasicAuth(l.user, l.pass)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("json-rpc transport: %v", err)
+	}
+	// we MUST read all of res.Body and call res.Close,
+	// otherwise the underlying connection cannot be re-used.
+	defer res.Body.Close()
+	res_bytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("json-rpc read response: %v", err)
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("json-rpc status code: %s", res.Status)
+	}
+	// cannot use json.NewDecoder: "The decoder introduces its own buffering
+	// and may read data from r beyond the JSON values requested."
+	var rpcres rpcResponse
+	err = json.Unmarshal(res_bytes, &rpcres)
+	if err != nil {
+		return fmt.Errorf("json-rpc unmarshal response: %v", err)
+	}
+	if rpcres.Id != body.Id {
+		return fmt.Errorf("json-rpc wrong ID returned: %v vs %v", rpcres.Id, body.Id)
+	}
+	if rpcres.Error != nil {
+		return fmt.Errorf("json-rpc error returned: %v", rpcres.Error)
+	}
+	if rpcres.Result == nil {
+		return fmt.Errorf("json-rpc missing result")
+	}
+	err = json.Unmarshal(*rpcres.Result, result)
+	if err != nil {
+		return fmt.Errorf("json-rpc unmarshal result: %v", err)
+	}
+	return nil
 }
 
 func (l L1CoreRPC) MakeAddress() (giga.Address, giga.Privkey, error) {
@@ -41,13 +104,8 @@ func (l L1CoreRPC) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, pa
 	return giga.NewTxn{}, fmt.Errorf("not implemented")
 }
 
-type DecodeRawTransactionArgs struct {
-	Hex string `json:"hexstring"`
-}
-
 func (l L1CoreRPC) DecodeTransaction(txn_hex string) (txn giga.RawTxn, err error) {
-	args := DecodeRawTransactionArgs{Hex: txn_hex}
-	err = l.client.Call("decoderawtransaction", &args, &txn)
+	err = l.request("decoderawtransaction", []any{txn_hex}, &txn)
 	return
 }
 

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -12,8 +12,9 @@ import (
 type L1 interface {
 	MakeAddress() (Address, Privkey, error)
 	MakeChildAddress(privkey Privkey, addressIndex uint32, isInternal bool) (Address, error)
-	MakeTransaction(amount CoinAmount, UTXOs []UTXO, payTo Address, fee CoinAmount, change Address, private_key Privkey) (Txn, error)
-	Send(Txn) error
+	MakeTransaction(amount CoinAmount, UTXOs []UTXO, payTo Address, fee CoinAmount, change Address, private_key Privkey) (NewTxn, error)
+	DecodeTransaction(txnHex string) (DecodedTxn, error)
+	Send(NewTxn) error
 }
 
 type Address string
@@ -108,14 +109,17 @@ type UTXOIterator interface {
 	getNext() UTXO
 }
 
-// Txn is a new Dogecoin Transaction being created by Gigawallet.
-// This is a workspace used to build up the transaction.
-type Txn struct {
+// NewTxn is a new Dogecoin Transaction being created by Gigawallet.
+type NewTxn struct {
 	TxnHex       string
-	InAmount     CoinAmount
+	TotalIn      CoinAmount
 	PayAmount    CoinAmount
 	FeeAmount    CoinAmount
 	ChangeAmount CoinAmount
+}
+
+// DecodedTxn is decoded from transaction hex data by L1/Core.
+type DecodedTxn struct {
 }
 
 // Invoice is a request for payment created by Gigawallet.

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -14,7 +14,8 @@ type L1 interface {
 	MakeChildAddress(privkey Privkey, addressIndex uint32, isInternal bool) (Address, error)
 	MakeTransaction(amount CoinAmount, UTXOs []UTXO, payTo Address, fee CoinAmount, change Address, private_key Privkey) (NewTxn, error)
 	DecodeTransaction(txnHex string) (RawTxn, error)
-	GetBlock(blockHash string, decodeTxns bool) (RpcBlock, error)
+	GetBlock(blockHash string) (RpcBlock, error)
+	GetTransaction(txnHash string) (RawTxn, error)
 	Send(NewTxn) error
 }
 
@@ -160,29 +161,25 @@ type RawTxnScriptPubKey struct {
 // Derived from the `getblock` Core API.
 // https://developer.bitcoin.org/reference/rpc/getblock.html
 type RpcBlock struct {
-	Hash              string       `json:"hash"`              // (string) the block hash (same as provided) hex
-	Confirmations     int          `json:"confirmations"`     // (numeric) The number of confirmations, or -1 if the block is not on the main chain
-	Size              int          `json:"size"`              // (numeric) The block size
-	StrippedSize      int          `json:"strippedsize"`      // (numeric) The block size excluding witness data
-	Weight            int          `json:"weight"`            // (numeric) The block weight as defined in BIP 141
-	Height            int          `json:"height"`            // (numeric) The block height or index
-	Version           int          `json:"version"`           // (numeric) The block version
-	VersionHex        string       `json:"versionHex"`        // (string) The block version formatted in hexadecimal
-	MerkleRoot        string       `json:"merkleroot"`        // (string) The merkle root, hex
-	Tx                []RpcBlockTx `json:"tx"`                // (json array) The transaction ids
-	Time              int          `json:"time"`              // (numeric) The block time expressed in UNIX epoch time
-	MedianTime        int          `json:"mediantime"`        // (numeric) The median block time expressed in UNIX epoch time
-	Nonce             int          `json:"nonce"`             // (numeric) The nonce
-	Bits              string       `json:"bits"`              // (string) The bits
-	Difficulty        int          `json:"difficulty"`        // (numeric) The difficulty
-	ChainWork         string       `json:"chainwork"`         // (string) Expected number of hashes required to produce the chain up to this block (in hex)
-	NTx               int          `json:"nTx"`               // (numeric) The number of transactions in the block
-	PreviousBlockHash string       `json:"previousblockhash"` // (string) The hash of the previous block, hex
-	NextBlockHash     string       `json:"nextblockhash"`     // (string) The hash of the next block, hex
-}
-type RpcBlockTx struct {
-	Hex string `json:"hex"` // (string) The transaction id
-	RawTxn
+	Hash              string          `json:"hash"`              // (string) the block hash (same as provided) (hex)
+	Confirmations     int             `json:"confirmations"`     // (numeric) The number of confirmations, or -1 if the block is not on the main chain
+	Size              int             `json:"size"`              // (numeric) The block size
+	StrippedSize      int             `json:"strippedsize"`      // (numeric) The block size excluding witness data
+	Weight            int             `json:"weight"`            // (numeric) The block weight as defined in BIP 141
+	Height            int             `json:"height"`            // (numeric) The block height or index
+	Version           int             `json:"version"`           // (numeric) The block version
+	VersionHex        string          `json:"versionHex"`        // (string) The block version formatted in hexadecimal
+	MerkleRoot        string          `json:"merkleroot"`        // (string) The merkle root (hex)
+	Tx                []string        `json:"tx"`                // (json array) The transaction ids
+	Time              int             `json:"time"`              // (numeric) The block time in seconds since UNIX epoch (Jan 1 1970 GMT)
+	MedianTime        int             `json:"mediantime"`        // (numeric) The median block time in seconds since UNIX epoch (Jan 1 1970 GMT)
+	Nonce             int             `json:"nonce"`             // (numeric) The nonce
+	Bits              string          `json:"bits"`              // (string) The bits
+	Difficulty        decimal.Decimal `json:"difficulty"`        // (numeric) The difficulty
+	ChainWork         string          `json:"chainwork"`         // (string) Expected number of hashes required to produce the chain up to this block (hex)
+	NTx               int             `json:"nTx"`               // (numeric) The number of transactions in the block
+	PreviousBlockHash string          `json:"previousblockhash"` // (string) The hash of the previous block (hex)
+	NextBlockHash     string          `json:"nextblockhash"`     // (string) The hash of the next block (hex)
 }
 
 // Invoice is a request for payment created by Gigawallet.

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -143,7 +143,7 @@ type RawTxnScriptSig struct {
 	Hex string `json:"hex"` // The script hex
 }
 type RawTxnVOut struct {
-	Value        string             `json:"value"`        // The value in DOGE (an exact decimal number)
+	Value        decimal.Decimal    `json:"value"`        // The value in DOGE (an exact decimal number)
 	N            int64              `json:"n"`            // The output number (VOut when spending)
 	ScriptPubKey RawTxnScriptPubKey `json:"scriptPubKey"` // The "pubkey script" (conditions for spending this output)
 }

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -14,6 +14,7 @@ type L1 interface {
 	MakeChildAddress(privkey Privkey, addressIndex uint32, isInternal bool) (Address, error)
 	MakeTransaction(amount CoinAmount, UTXOs []UTXO, payTo Address, fee CoinAmount, change Address, private_key Privkey) (NewTxn, error)
 	DecodeTransaction(txnHex string) (RawTxn, error)
+	GetBlock(blockHash string, decodeTxns bool) (RpcBlock, error)
 	Send(NewTxn) error
 }
 
@@ -153,6 +154,35 @@ type RawTxnScriptPubKey struct {
 	ReqSigs   int64    `json:"reqSigs"`   // Number of required signatures
 	Type      string   `json:"type"`      // Script type: 'pubkeyhash' (P2PKH)
 	Addresses []string `json:"addresses"` // Array of dogecoin addresses accepted by the script
+}
+
+// RpcBlock is decoded from block hex data by L1/Core.
+// Derived from the `getblock` Core API.
+// https://developer.bitcoin.org/reference/rpc/getblock.html
+type RpcBlock struct {
+	Hash              string       `json:"hash"`              // (string) the block hash (same as provided) hex
+	Confirmations     int          `json:"confirmations"`     // (numeric) The number of confirmations, or -1 if the block is not on the main chain
+	Size              int          `json:"size"`              // (numeric) The block size
+	StrippedSize      int          `json:"strippedsize"`      // (numeric) The block size excluding witness data
+	Weight            int          `json:"weight"`            // (numeric) The block weight as defined in BIP 141
+	Height            int          `json:"height"`            // (numeric) The block height or index
+	Version           int          `json:"version"`           // (numeric) The block version
+	VersionHex        string       `json:"versionHex"`        // (string) The block version formatted in hexadecimal
+	MerkleRoot        string       `json:"merkleroot"`        // (string) The merkle root, hex
+	Tx                []RpcBlockTx `json:"tx"`                // (json array) The transaction ids
+	Time              int          `json:"time"`              // (numeric) The block time expressed in UNIX epoch time
+	MedianTime        int          `json:"mediantime"`        // (numeric) The median block time expressed in UNIX epoch time
+	Nonce             int          `json:"nonce"`             // (numeric) The nonce
+	Bits              string       `json:"bits"`              // (string) The bits
+	Difficulty        int          `json:"difficulty"`        // (numeric) The difficulty
+	ChainWork         string       `json:"chainwork"`         // (string) Expected number of hashes required to produce the chain up to this block (in hex)
+	NTx               int          `json:"nTx"`               // (numeric) The number of transactions in the block
+	PreviousBlockHash string       `json:"previousblockhash"` // (string) The hash of the previous block, hex
+	NextBlockHash     string       `json:"nextblockhash"`     // (string) The hash of the next block, hex
+}
+type RpcBlockTx struct {
+	Hex string `json:"hex"` // (string) The transaction id
+	RawTxn
 }
 
 // Invoice is a request for payment created by Gigawallet.

--- a/pkg/dogecoin/libdogecoin.go
+++ b/pkg/dogecoin/libdogecoin.go
@@ -121,6 +121,13 @@ func (l L1Libdogecoin) DecodeTransaction(txnHex string) (giga.RawTxn, error) {
 	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
+func (l L1Libdogecoin) GetBlock(blockHash string, decodeTxns bool) (txn giga.RpcBlock, err error) {
+	if l.fallback != nil {
+		return l.fallback.GetBlock(blockHash, decodeTxns)
+	}
+	return giga.RpcBlock{}, fmt.Errorf("not implemented")
+}
+
 func (l L1Libdogecoin) Send(txn giga.NewTxn) error {
 	if l.fallback != nil {
 		return l.fallback.Send(txn)

--- a/pkg/dogecoin/libdogecoin.go
+++ b/pkg/dogecoin/libdogecoin.go
@@ -121,11 +121,18 @@ func (l L1Libdogecoin) DecodeTransaction(txnHex string) (giga.RawTxn, error) {
 	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
-func (l L1Libdogecoin) GetBlock(blockHash string, decodeTxns bool) (txn giga.RpcBlock, err error) {
+func (l L1Libdogecoin) GetBlock(blockHash string) (txn giga.RpcBlock, err error) {
 	if l.fallback != nil {
-		return l.fallback.GetBlock(blockHash, decodeTxns)
+		return l.fallback.GetBlock(blockHash)
 	}
 	return giga.RpcBlock{}, fmt.Errorf("not implemented")
+}
+
+func (l L1Libdogecoin) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
+	if l.fallback != nil {
+		return l.fallback.GetTransaction(txnHash)
+	}
+	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
 func (l L1Libdogecoin) Send(txn giga.NewTxn) error {

--- a/pkg/dogecoin/libdogecoin.go
+++ b/pkg/dogecoin/libdogecoin.go
@@ -114,11 +114,11 @@ func (l L1Libdogecoin) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO
 	return giga.NewTxn{TxnHex: tx_hex, TotalIn: totalIn, PayAmount: amount, FeeAmount: fee, ChangeAmount: change_amt}, nil
 }
 
-func (l L1Libdogecoin) DecodeTransaction(txnHex string) (giga.DecodedTxn, error) {
+func (l L1Libdogecoin) DecodeTransaction(txnHex string) (giga.RawTxn, error) {
 	if l.fallback != nil {
 		return l.fallback.DecodeTransaction(txnHex)
 	}
-	return giga.DecodedTxn{}, fmt.Errorf("not implemented")
+	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
 func (l L1Libdogecoin) Send(txn giga.NewTxn) error {

--- a/pkg/dogecoin/libdogecoin.go
+++ b/pkg/dogecoin/libdogecoin.go
@@ -20,11 +20,14 @@ const (
 var _ giga.L1 = L1Libdogecoin{}
 
 // NewL1Libdogecoin returns a giga.L1 implementor that uses libdogecoin
-func NewL1Libdogecoin(config giga.Config) (L1Libdogecoin, error) {
-	return L1Libdogecoin{}, nil
+// Allows (non-implemented) functions to delegate to another L1 implementation.
+func NewL1Libdogecoin(config giga.Config, fallback giga.L1) (L1Libdogecoin, error) {
+	return L1Libdogecoin{fallback: fallback}, nil
 }
 
-type L1Libdogecoin struct{}
+type L1Libdogecoin struct {
+	fallback giga.L1
+}
 
 func (l L1Libdogecoin) MakeAddress() (giga.Address, giga.Privkey, error) {
 	libdogecoin.W_context_start()
@@ -44,13 +47,13 @@ func (l L1Libdogecoin) MakeChildAddress(privkey giga.Privkey, addressIndex uint3
 	return giga.Address(pub), nil
 }
 
-func (l L1Libdogecoin) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.Txn, error) {
+func (l L1Libdogecoin) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.NewTxn, error) {
 	libdogecoin.W_context_start()
 	defer libdogecoin.W_context_stop()
 
 	// validate transaction amounts
 	if len(UTXOs) < 1 {
-		return giga.Txn{}, fmt.Errorf("cannot make a txn with zero UTXOs")
+		return giga.NewTxn{}, fmt.Errorf("cannot make a txn with zero UTXOs")
 	}
 	totalIn := giga.ZeroCoins
 	for _, UTXO := range UTXOs {
@@ -58,7 +61,7 @@ func (l L1Libdogecoin) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO
 	}
 	minRequired := amount.Add(fee)
 	if totalIn.LessThan(minRequired) {
-		return giga.Txn{}, fmt.Errorf("UTXOs do not hold enough value to pay amount plus fee: %s vs %s", totalIn.String(), minRequired.String())
+		return giga.NewTxn{}, fmt.Errorf("UTXOs do not hold enough value to pay amount plus fee: %s vs %s", totalIn.String(), minRequired.String())
 	}
 
 	// create the transaction
@@ -68,13 +71,13 @@ func (l L1Libdogecoin) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO
 	// add the UTXOs to spend in the transaction
 	for _, UTXO := range UTXOs {
 		if libdogecoin.W_add_utxo(tx, UTXO.TxnID, UTXO.VOut) != 1 {
-			return giga.Txn{}, fmt.Errorf("libdogecoin error adding UTXO: %v", UTXO)
+			return giga.NewTxn{}, fmt.Errorf("libdogecoin error adding UTXO: %v", UTXO)
 		}
 	}
 
 	// add output: P2PKH to the payTo Address
 	if libdogecoin.W_add_output(tx, string(payTo), amount.String()) != 1 {
-		return giga.Txn{}, fmt.Errorf("libdogecoin error adding payTo output")
+		return giga.NewTxn{}, fmt.Errorf("libdogecoin error adding payTo output")
 	}
 
 	// finalize the transaction: adds a change output if necessary
@@ -82,16 +85,25 @@ func (l L1Libdogecoin) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO
 	// the final argument is the change_address which will be used to add a txn output if there is any change.
 	tx_hex := libdogecoin.W_finalize_transaction(tx, string(payTo), fee.String(), totalIn.String(), string(change))
 	if tx_hex == "" {
-		return giga.Txn{}, fmt.Errorf("libdogecoin error finalizing transaction")
+		return giga.NewTxn{}, fmt.Errorf("libdogecoin error finalizing transaction")
 	}
+
+	// FIXME: safer to extract this from the transaction output added by libdogecoin (if any)
+	change_amt := totalIn.Sub(amount).Sub(fee)
 
 	// we have the payer's private key in WIF format.
 	// generate the payer's public P2PKH Address from the private key.
 	p2pkh_pub := libdogecoin.W_generate_derived_hd_pub_key(string(private_key_wif))
+	if p2pkh_pub == "" {
+		return giga.NewTxn{}, fmt.Errorf("libdogecoin error generating pubkey for privkey")
+	}
 
 	// sign the transaction: sign each input UTXO with our public and private key
 	// note: assumes all UTXOs were created with standard P2PKH script (no Multisig etc)
-	libdogecoin.W_sign_transaction(tx, p2pkh_pub, string(private_key_wif))
+	// and the same private key (FIXME: won't be true for HD-Wallet UTXOs)
+	if libdogecoin.W_sign_transaction(tx, p2pkh_pub, string(private_key_wif)) != 1 {
+		return giga.NewTxn{}, fmt.Errorf("libdogecoin failed to sign transaction")
+	}
 
 	// we might need to sign each input separately (if each UTXO has a different pay-to Address,
 	//                                      don't we need a different private key for each one?)
@@ -99,10 +111,19 @@ func (l L1Libdogecoin) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO
 	// 	tx_hex = libdogecoin.W_sign_raw_transaction(n, tx_hex, script_pubkey, SIGHASH_ALL, private_key_wif)
 	// }
 
-	change_amt := totalIn.Sub(amount).Sub(fee)
-	return giga.Txn{TxnHex: tx_hex, InAmount: totalIn, PayAmount: amount, FeeAmount: fee, ChangeAmount: change_amt}, nil
+	return giga.NewTxn{TxnHex: tx_hex, TotalIn: totalIn, PayAmount: amount, FeeAmount: fee, ChangeAmount: change_amt}, nil
 }
 
-func (l L1Libdogecoin) Send(txn giga.Txn) error {
-	return nil
+func (l L1Libdogecoin) DecodeTransaction(txnHex string) (giga.DecodedTxn, error) {
+	if l.fallback != nil {
+		return l.fallback.DecodeTransaction(txnHex)
+	}
+	return giga.DecodedTxn{}, fmt.Errorf("not implemented")
+}
+
+func (l L1Libdogecoin) Send(txn giga.NewTxn) error {
+	if l.fallback != nil {
+		return l.fallback.Send(txn)
+	}
+	return fmt.Errorf("not implemented")
 }

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -32,8 +32,12 @@ func (l L1Mock) DecodeTransaction(txnHex string) (giga.RawTxn, error) {
 	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
-func (l L1Mock) GetBlock(blockHash string, decodeTxns bool) (txn giga.RpcBlock, err error) {
+func (l L1Mock) GetBlock(blockHash string) (txn giga.RpcBlock, err error) {
 	return giga.RpcBlock{}, fmt.Errorf("not implemented")
+}
+
+func (l L1Mock) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
+	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
 func (l L1Mock) Send(txn giga.NewTxn) error {

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -28,8 +28,8 @@ func (l L1Mock) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo
 	return giga.NewTxn{}, fmt.Errorf("not implemented")
 }
 
-func (l L1Mock) DecodeTransaction(txnHex string) (giga.DecodedTxn, error) {
-	return giga.DecodedTxn{}, fmt.Errorf("not implemented")
+func (l L1Mock) DecodeTransaction(txnHex string) (giga.RawTxn, error) {
+	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
 func (l L1Mock) Send(txn giga.NewTxn) error {

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -24,10 +24,14 @@ func (l L1Mock) MakeChildAddress(privkey giga.Privkey, addressIndex uint32, isIn
 	return "mockChildAddress", nil
 }
 
-func (l L1Mock) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key giga.Privkey) (giga.Txn, error) {
-	return giga.Txn{}, fmt.Errorf("not implemented")
+func (l L1Mock) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key giga.Privkey) (giga.NewTxn, error) {
+	return giga.NewTxn{}, fmt.Errorf("not implemented")
 }
 
-func (l L1Mock) Send(txn giga.Txn) error {
-	return nil
+func (l L1Mock) DecodeTransaction(txnHex string) (giga.DecodedTxn, error) {
+	return giga.DecodedTxn{}, fmt.Errorf("not implemented")
+}
+
+func (l L1Mock) Send(txn giga.NewTxn) error {
+	return fmt.Errorf("not implemented")
 }

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -32,6 +32,10 @@ func (l L1Mock) DecodeTransaction(txnHex string) (giga.RawTxn, error) {
 	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
+func (l L1Mock) GetBlock(blockHash string, decodeTxns bool) (txn giga.RpcBlock, err error) {
+	return giga.RpcBlock{}, fmt.Errorf("not implemented")
+}
+
 func (l L1Mock) Send(txn giga.NewTxn) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -12,8 +12,6 @@ type Store interface {
 	ListInvoices(account Address, cursor int, limit int) (items []Invoice, next_cursor int, err error)
 	// GetPendingInvoices sends all invoices that are pending to the given channel.
 	GetPendingInvoices() (<-chan Invoice, error)
-	// MarkInvoiceAsPaid marks the invoice with the given ID as paid.
-	MarkInvoiceAsPaid(id Address) error
 
 	// StoreAccount stores an account.
 	StoreAccount(account Account) error
@@ -23,4 +21,30 @@ type Store interface {
 	// List all unreserved UTXOs in the account's wallet.
 	// Unreserved means not already being used in a pending transaction.
 	GetAllUnreservedUTXOs(account Address) ([]UTXO, error)
+
+	// Commit a list of Update structs transactionally.
+	// This interface suports both SQL and Object stores (with conditional puts)
+	Commit(updates []any) error
+}
+
+// Upsert: Account, unconditional.
+type UpsertAccount struct {
+	Account Account
+}
+
+// Update: next external key numbers in an Account.
+type UpdateAccountNextExternal struct {
+	Address  Address
+	KeyIndex uint32
+}
+
+// Upsert: Invoice, unconditional.
+type UpsertInvoice struct {
+	Invoice Invoice
+}
+
+// MarkInvoiceAsPaid marks the invoice with the given ID as paid.
+// Update, unconditional.
+type MarkInvoiceAsPaid struct {
+	InvoiceID Address
 }

--- a/pkg/store/mock.go
+++ b/pkg/store/mock.go
@@ -79,3 +79,7 @@ func (m Mock) GetAccountByAddress(id giga.Address) (giga.Account, error) {
 func (m Mock) GetAllUnreservedUTXOs(account giga.Address) ([]giga.UTXO, error) {
 	return nil, nil
 }
+
+func (m Mock) Commit(updates []any) error {
+	return nil
+}

--- a/pkg/webapi.go
+++ b/pkg/webapi.go
@@ -55,6 +55,9 @@ func (t WebAPI) Run(started, stopped chan bool, stop chan context.Context) error
 		// POST /invoice/:invoiceID/payfrom/:foreignID -> { status } pay invoice from internal account
 		mux.POST("/invoice/:invoiceID/payfrom/:foreignID", t.payInvoiceFromInternal)
 
+		// POST /decode-txn -> test decoding
+		mux.POST("/decode-txn", t.decodeTxn)
+
 		// POST { amount } /invoice/:invoiceID/refundtoaddr/:address -> { status } refund all or part of a paid invoice to address
 
 		// POST { amount } /invoice/:invoiceID/refundtoacc/:foreignID -> { status } refund all or part of a paid invoice to account
@@ -254,6 +257,25 @@ func (t WebAPI) getAccount(w http.ResponseWriter, r *http.Request, p httprouter.
 		return
 	}
 	sendResponse(w, acc)
+}
+
+type DecodeTxnRequest struct {
+	Hex string `json:"hex"`
+}
+
+func (t WebAPI) decodeTxn(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+	var o DecodeTxnRequest
+	err := json.NewDecoder(r.Body).Decode(&o)
+	if err != nil {
+		sendBadRequest(w, fmt.Sprintf("bad request body (expecting JSON): %v", err))
+		return
+	}
+	rawTxn, err := t.api.L1.DecodeTransaction(o.Hex)
+	if err != nil {
+		sendBadRequest(w, fmt.Sprintf("error decoding transaction: %v", err))
+		return
+	}
+	sendResponse(w, rawTxn)
 }
 
 // Helpers

--- a/pkg/webapi.go
+++ b/pkg/webapi.go
@@ -78,12 +78,9 @@ func (t WebAPI) Run(started, stopped chan bool, stop chan context.Context) error
 			}
 		}()
 		started <- true
-		select {
-		case ctx := <-stop:
-			// do some shutdown stuff then signal we're done
-			t.srv.Shutdown(ctx)
-			stopped <- true
-		}
+		ctx := <-stop
+		t.srv.Shutdown(ctx)
+		stopped <- true
 	}()
 	return nil
 }


### PR DESCRIPTION
Listens to core for new blocks, then fetches the block and all transactions in that block - so we can store new UTXOs for our wallets, and mark invoices paid when transactions pay to invoice addresses.

Refactored the Store API to support multiple changes in a single transactional request, without the "conversational" style that traditional databases use (where you open a transaction, perform queries, perform updates, then commit.)

Most modern object databases support conditional writes and transactional requests using this pattern, so you could for example use DynamoDB or MongoDB behind this interface, as well as SQL databases.
