### PR TITLE
update event types 

### DIFF
--- a/pkg/core/receiver.go
+++ b/pkg/core/receiver.go
@@ -43,7 +43,7 @@ func (z CoreReceiver) Run(started, stopped chan bool, stop chan context.Context)
 	}
 	sock.SetRcvtimeo(2 * time.Second)
 	z.sock = sock
-	z.bus.Send(giga.MSG_SYS, fmt.Sprintf("ZMQ: connecting to: %s", z.nodeAddress))
+	z.bus.Send(giga.SYS_STARTUP, fmt.Sprintf("ZMQ: connecting to: %s", z.nodeAddress))
 	err = sock.Connect(z.nodeAddress)
 	if err != nil {
 		return err
@@ -72,13 +72,13 @@ func (z CoreReceiver) Run(started, stopped chan bool, stop chan context.Context)
 				case zmq4.Errno:
 					if err == zmq4.Errno(syscall.ETIMEDOUT) {
 						// handle timeouts by looping again
-						z.bus.Send(giga.MSG_SYS, "ZMQ: connection timeout")
+						z.bus.Send(giga.SYS_ERR, "ZMQ: connection timeout")
 						continue
 					} else if err == zmq4.Errno(syscall.EAGAIN) {
 						continue
 					} else {
 						// handle other ZeroMQ error codes
-						z.bus.Send(giga.MSG_SYS, fmt.Sprintf("ZMQ err: %s", err))
+						z.bus.Send(giga.SYS_ERR, fmt.Sprintf("ZMQ err: %s", err))
 						continue
 					}
 				default:

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -5,35 +5,68 @@ package giga
 // bus.Send(INV_PAYMENT_REFUNDED, payment)
 // bus.Send(ACC_CREATED, acc)
 
+// Interface for any event
+type EventType interface {
+	Type() string
+}
+
+// slice of all msg types for config funcs lookup
+var EVENT_TYPES []EventType = []EventType{EVENT_ALL("ALL"),
+	EVENT_SYS("SYS"),
+	EVENT_NET("NET"),
+	EVENT_ACC("ACC"),
+	EVENT_INV("INV")}
+
 // Special category, do not use directly, represents *
 type EVENT_ALL string
+
+func (e EVENT_ALL) Type() string {
+	return "ALL"
+}
 
 // System Events
 type EVENT_SYS string
 
+func (e EVENT_SYS) Type() string {
+	return "SYS"
+}
+
 const (
 	SYS_STARTUP EVENT_SYS = "STARTUP"
+	SYS_ERR     EVENT_SYS = "ERR"
 )
 
 // Network Events
 type EVENT_NET string
 
+func (e EVENT_NET) Type() string {
+	return "NET"
+}
+
 // Account Events
 type EVENT_ACC string
 
+func (e EVENT_ACC) Type() string {
+	return "ACC"
+}
+
 const (
-	ACC_CREATED EVENT_ACC = "ACC_CREATED"
-	ACC_UPDATED EVENT_ACC = "ACC_UPDATED"
-	ACC_PAYMENT EVENT_ACC = "ACC_PAYMENT"
+	ACC_CREATED EVENT_ACC = "CREATED"
+	ACC_UPDATED EVENT_ACC = "UPDATED"
+	ACC_PAYMENT EVENT_ACC = "PAYMENT"
 )
 
 // Invoice Events
 type EVENT_INV string
 
+func (e EVENT_INV) Type() string {
+	return "INV"
+}
+
 const (
-	INV_CREATED          EVENT_INV = "INV_CREATED"
-	INV_UPDATED          EVENT_INV = "INV_UPDATED"
-	INV_PAYMENT_RECEIVED EVENT_INV = "INV_PAYMENT_RECEIVED"
-	INV_PAYMENT_VERIFIED EVENT_INV = "INV_PAYMENT_VERIFIED"
-	INV_PAYMENT_REFUNDED EVENT_INV = "INV_PAYMENT_REFUNDED"
+	INV_CREATED          EVENT_INV = "CREATED"
+	INV_UPDATED          EVENT_INV = "UPDATED"
+	INV_PAYMENT_RECEIVED EVENT_INV = "PAYMENT_RECEIVED"
+	INV_PAYMENT_VERIFIED EVENT_INV = "PAYMENT_VERIFIED"
+	INV_PAYMENT_REFUNDED EVENT_INV = "PAYMENT_REFUNDED"
 )

--- a/pkg/receivers/logger.go
+++ b/pkg/receivers/logger.go
@@ -34,8 +34,9 @@ func (l MessageLogger) Run(started, stopped chan bool, stop chan context.Context
 				close(stopped)
 				return
 			case msg := <-l.Rec:
-				l.Log.Printf("%s (%s): %s\n",
-					msg.MessageType,
+				l.Log.Printf("%s:%s (%s): %s\n",
+					msg.EventType.Type(),
+					msg.EventType,
 					msg.ID,
 					msg.Message)
 			}
@@ -62,11 +63,11 @@ func SetupLoggers(cond *conductor.Conductor, bus giga.MessageBus, conf giga.Conf
 		l := NewMessageLogger(c.Path)
 		cond.Service(fmt.Sprintf("Logger %s", c.Path), l)
 
-		types := []giga.MessageType{}
+		types := []giga.EventType{}
 		for _, t := range c.Types {
 			match := false
-			for _, x := range giga.MSG_TYPES {
-				if t == string(x) {
+			for _, x := range giga.EVENT_TYPES {
+				if t == x.Type() {
 					match = true
 					types = append(types, x)
 				}


### PR DESCRIPTION
Replaced the old MSG_TYPES with  EventType that understands event categories for filtering etc.. should provide more obvious msgs (see event.log when you run the service) and an easy place to find out what they all mean (events.go)