### PR TITLE
Populate account_address with past and future HD Wallet addresses.

### DIFF
--- a/pkg/broker/payments.go
+++ b/pkg/broker/payments.go
@@ -22,11 +22,11 @@ func (p *PaymentBroker) Subscribe(ch chan<- giga.BrokerEvent) {
 }
 
 func (p PaymentBroker) Run(started, stopped chan bool, stop chan context.Context) error {
-	storedInvoices, err := p.store.GetPendingInvoices()
-	if err != nil {
-		log.Println("Error getting pending invoices:", err)
-		return err
-	}
+	// storedInvoices, err := p.store.GetPendingInvoices()
+	// if err != nil {
+	// 	log.Println("Error getting pending invoices:", err)
+	// 	return err
+	// }
 	go func() {
 		started <- true
 		for {
@@ -59,8 +59,8 @@ func (p PaymentBroker) Run(started, stopped chan bool, stop chan context.Context
 						log.Println("Payment Broker couldn't commit txn, mark invoice paid", err)
 					}
 				}
-			case e := <-storedInvoices:
-				p.sendEvent(giga.BrokerEvent{Type: giga.NewInvoice, ID: string(e.ID)})
+			// case e := <-storedInvoices:
+			// 	p.sendEvent(giga.BrokerEvent{Type: giga.NewInvoice, ID: string(e.ID)})
 			case <-stop:
 				stopped <- true
 				return

--- a/pkg/chaintracker/chainfollower.go
+++ b/pkg/chaintracker/chainfollower.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DOGECOIN_GENESIS_BLOCK_HASH = "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691"
+	DOGECOIN_GENESIS_BLOCK_HASH = "82bc68038f6034c0596b6e313729793a887fded6e92a31fbdf70863f89d9bea2" // Mainnet 1
 	RETRY_DELAY                 = 5 * time.Second
 	CONFLICT_DELAY              = 250 * time.Millisecond // quarter second
 	BATCH_SIZE                  = 100                    // number of blocks
@@ -303,7 +303,7 @@ func (c *ChainFollower) processBlock(tx giga.StoreTransaction, block giga.RpcBlo
 					// These script-types always contain a single address.
 					pkhAddress := giga.Address(vout.ScriptPubKey.Addresses[0])
 					// Use an address-to-wallet index (utxo_account_i) to find the wallet.
-					accountID, keyIndex, err := tx.FindAccountForAddress(pkhAddress)
+					accountID, keyIndex, isInternal, err := tx.FindAccountForAddress(pkhAddress)
 					if err != nil {
 						if giga.IsNotFoundError(err) {
 							log.Println("ChainFollower: no account matches new UTXO:", txn_id, vout.N)
@@ -313,7 +313,7 @@ func (c *ChainFollower) processBlock(tx giga.StoreTransaction, block giga.RpcBlo
 							return false // retry.
 						}
 					} else {
-						err = tx.CreateUTXO(txn_id, vout.N, vout.Value, scriptType, pkhAddress, accountID, keyIndex, block.Height)
+						err = tx.CreateUTXO(txn_id, vout.N, vout.Value, scriptType, pkhAddress, accountID, keyIndex, isInternal, block.Height)
 						if err != nil {
 							log.Println("ChainFollower: processBlock: cannot create UTXO in DB:", err, txn_id, vout.N)
 							c.sleepForRetry(err)

--- a/pkg/chaintracker/chainfollower.go
+++ b/pkg/chaintracker/chainfollower.go
@@ -141,7 +141,7 @@ func (c *ChainFollower) transactionalRollForward(pos ChainPos) ChainPos {
 	var blockCount int = 0
 	tx := c.beginStoreTxn()
 	for pos.NextBlockHash != "" {
-		log.Println("ChainFollower: fetching block:", pos.NextBlockHash)
+		//log.Println("ChainFollower: fetching block:", pos.NextBlockHash)
 		block := c.fetchBlock(pos.NextBlockHash)
 		if block.Confirmations != -1 {
 			// Still on-chain, so update chainstate from block transactions.
@@ -306,7 +306,7 @@ func (c *ChainFollower) processBlock(tx giga.StoreTransaction, block giga.RpcBlo
 					accountID, keyIndex, isInternal, err := tx.FindAccountForAddress(pkhAddress)
 					if err != nil {
 						if giga.IsNotFoundError(err) {
-							log.Println("ChainFollower: no account matches new UTXO:", txn_id, vout.N)
+							//log.Println("ChainFollower: no account matches new UTXO:", txn_id, vout.N)
 						} else {
 							log.Println("ChainFollower: processBlock: cannot query FindAccountForAddress in DB:", err, pkhAddress)
 							c.sleepForRetry(err)

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -27,7 +27,7 @@ type L1 interface {
 }
 
 type Address string // Dogecoin address (base-58 public key hash aka PKH)
-type Privkey string //
+type Privkey string // Extended Private Key for HD Wallet
 type CoinAmount = decimal.Decimal
 
 var ZeroCoins = decimal.NewFromInt(0)                         // 0 DOGE

--- a/pkg/store/mock.go
+++ b/pkg/store/mock.go
@@ -1,8 +1,6 @@
 package store
 
 import (
-	"log"
-
 	giga "github.com/dogecoinfoundation/gigawallet/pkg"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -20,12 +18,6 @@ type Mock struct {
 func (m Mock) MarkInvoiceAsPaid(id giga.Address) error {
 	//TODO implement me
 	panic("implement me")
-}
-
-func (m Mock) GetPendingInvoices() (<-chan giga.Invoice, error) {
-	//TODO implement me
-	log.Print("GetPendingInvoices: not implemented")
-	return make(chan giga.Invoice), nil
 }
 
 // NewMock returns a giga.PaymentsStore implementor that stores orders in memory


### PR DESCRIPTION
The account_address table associates dogecoin addresses with an Account so we can find the owner account of UTXOs as we process new blocks.

This is necessary so we can spend those UTXOs later, and recognise payments toward Invoices.

Effectively the account_address table contains a pool of both used and not-yet-used HD Wallet addresses for every account in Gigawallet.

There are a few other fixes, e.g. tracking whether a KeyIndex is an internal (change) or external (invoice) address, removed the old GetPendingInvoices stub.