### PR TITLE
Auto SYNC with the blockchain on the Core Node

### DIFF
--- a/pkg/chaintracker/chainfollower.go
+++ b/pkg/chaintracker/chainfollower.go
@@ -23,6 +23,7 @@ type ChainFollower struct {
 	Commands         chan any                     // receive ReSyncChainFollowerCmd etc.
 	stopping         bool                         // set to exit the main loop.
 	SetSync          *giga.ReSyncChainFollowerCmd // pending ReSync command.
+	buildAddressIndex bool                         // enable building the Address Index.
 }
 
 type ChainPos struct {
@@ -232,8 +233,10 @@ func (c *ChainFollower) transactionalRollForward(pos ChainPos) ChainPos {
 		}
 	}
 	if blockCount > 0 {
-		// Add addresses => block-heights to the Address Index.
-		tx.IndexAddresses(addressBlocks)
+		if c.buildAddressIndex {
+			// Add addresses => block-heights to the Address Index.
+			tx.IndexAddresses(addressBlocks)
+		}
 		// Increment the chain-seq number on affected accounts.
 		tx.IncChainSeqForAccounts(mapKeys(affectedAcconts))
 		// We have made forward progress: commit the transaction.

--- a/pkg/chaintracker/chainfollower.go
+++ b/pkg/chaintracker/chainfollower.go
@@ -9,20 +9,20 @@ import (
 )
 
 const (
-	DOGECOIN_GENESIS_BLOCK_HASH = "82bc68038f6034c0596b6e313729793a887fded6e92a31fbdf70863f89d9bea2" // Mainnet 1
-	RETRY_DELAY                 = 5 * time.Second                                                    // for RPC and Database errors.
-	CONFLICT_DELAY              = 250 * time.Millisecond                                             // for Database conflicts (concurrent transactions)
-	BLOCKS_PER_COMMIT           = 10                                                                 // number of blocks per database commit.
+	RETRY_DELAY       = 5 * time.Second        // for RPC and Database errors.
+	WRONG_CHAIN_DELAY = 5 * time.Minute        // for "Wrong Chain" error (essentially stop)
+	CONFLICT_DELAY    = 250 * time.Millisecond // for Database conflicts (concurrent transactions)
+	BLOCKS_PER_COMMIT = 10                     // number of blocks per database commit.
 )
 
 type ChainFollower struct {
-	l1               giga.L1
-	store            giga.Store
-	tx               giga.StoreTransaction        // non-nil during a transaction (for cleanup)
-	ReceiveBestBlock chan string                  // receive from TipChaser.
-	Commands         chan any                     // receive ReSyncChainFollowerCmd etc.
-	stopping         bool                         // set to exit the main loop.
-	SetSync          *giga.ReSyncChainFollowerCmd // pending ReSync command.
+	l1                giga.L1
+	store             giga.Store
+	tx                giga.StoreTransaction        // non-nil during a transaction (for cleanup)
+	ReceiveBestBlock  chan string                  // receive from TipChaser.
+	Commands          chan any                     // receive ReSyncChainFollowerCmd etc.
+	stopping          bool                         // set to exit the main loop.
+	SetSync           *giga.ReSyncChainFollowerCmd // pending ReSync command.
 	buildAddressIndex bool                         // enable building the Address Index.
 }
 
@@ -93,18 +93,7 @@ func (c *ChainFollower) serviceMain() {
 	// the Best Block we have stored (and all prior blocks per previousblockhash)
 	// We MUST update the chainstate before we update this hash.
 	log.Println("ChainFollower: fetching chainstate")
-	state := c.fetchChainState()
-
-	// Work out the current Chain Position.
-	var pos ChainPos
-	if state.BestBlockHash == "" {
-		// No BestBlockHash stored, so we must be starting from scratch.
-		// Walk the blockchain from the genesis block.
-		pos = ChainPos{"", 0, DOGECOIN_GENESIS_BLOCK_HASH}
-	} else {
-		// Walk forwards on the blockchain from BestBlockHash until we reach the tip.
-		pos = ChainPos{state.BestBlockHash, state.BestBlockHeight, ""}
-	}
+	pos := c.fetchStartingPos()
 
 	// Execute any pending commands.
 	if c.SetSync != nil {
@@ -142,6 +131,64 @@ func (c *ChainFollower) serviceMain() {
 
 		// Walk forwards on the blockchain until we reach the tip.
 		pos = c.followChainToTip(pos)
+	}
+}
+
+func (c *ChainFollower) fetchStartingPos() ChainPos {
+	// Retry loop for transaction error or wrong-chain error.
+	for {
+		state := c.fetchChainState()
+		rootBlock := c.fetchBlockHash(1)
+		if state.BestBlockHash != "" {
+			// Resume sync.
+			// Make sure we're syncing the same blockchain as before.
+			if state.RootHash == rootBlock {
+				log.Println("ChainFollower: RESUME SYNC :", state.BestBlockHeight)
+				return ChainPos{state.BestBlockHash, state.BestBlockHeight, ""}
+			} else {
+				log.Println("ChainFollower: WRONG CHAIN!")
+				log.Println("ChainFollower: Block#1 we have in DB:", state.RootHash)
+				log.Println("ChainFollower: Block#1 on Core Node:", rootBlock)
+				log.Println("ChainFollower: Please re-connect to a Core Node running the same blockchain we have in the database, or reset your database tables (please see manual for help)")
+				c.sleepForRetry(nil, WRONG_CHAIN_DELAY)
+			}
+		} else {
+			// Initial sync.
+			// Start at least 100 blocks back from the current Tip,
+			// so we're working with a well-confirmed starting block.
+			firstHeight := c.fetchBlockCount() - 100
+			if firstHeight < 1 {
+				firstHeight = 1
+			}
+			firstBlockHash := c.fetchBlockHash(firstHeight)
+			log.Println("ChainFollower: INITIAL SYNC")
+			log.Println("ChainFollower: Block#1 on Core Node:", rootBlock)
+			log.Println("ChainFollower: Initial Block Height:", firstHeight)
+			// Commit the initial start position to the database.
+			// Wrap the following in a transaction with retry.
+			tx := c.beginStoreTxn()
+			err := tx.UpdateChainState(giga.ChainState{
+				RootHash:        rootBlock,
+				FirstHeight:     firstHeight,
+				BestBlockHash:   firstBlockHash,
+				BestBlockHeight: firstHeight,
+			}, true)
+			if err != nil {
+				tx.Rollback()
+				log.Println("ChainFollower: fetchStartingPos: cannot UpdateChainState:", err)
+				c.sleepForRetry(err, 0)
+				continue // retry.
+			}
+			err = tx.Commit()
+			if err != nil {
+				log.Println("ChainFollower: fetchStartingPos: cannot commit DB transaction:", err)
+				c.sleepForRetry(err, 0)
+				continue // retry.
+			}
+			// Now start again: should resume sync this time.
+			log.Println("ChainFollower: wrote chainstate. ready to resume sync.")
+			continue
+		}
 	}
 }
 
@@ -297,7 +344,7 @@ func (c *ChainFollower) rollBackChainStateToPos(pos ChainPos) {
 		if err != nil {
 			tx.Rollback()
 			log.Println("ChainFollower: rollBackChainStateToPos: cannot IncAccountsAffectedByRollback:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
 		// Roll back chainstate above maxValidHeight.
@@ -305,31 +352,31 @@ func (c *ChainFollower) rollBackChainStateToPos(pos ChainPos) {
 		if err != nil {
 			tx.Rollback()
 			log.Println("ChainFollower: rollBackChainStateToPos: cannot RevertUTXOsAboveHeight:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
 		err = tx.RevertTxnsAboveHeight(maxValidHeight)
 		if err != nil {
 			tx.Rollback()
 			log.Println("ChainFollower: rollBackChainStateToPos: cannot RevertTxnsAboveHeight:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
 		// Update Best Block in the database (checkpoint for restart)
 		err = tx.UpdateChainState(giga.ChainState{
 			BestBlockHash:   pos.BlockHash,
 			BestBlockHeight: pos.BlockHeight,
-		})
+		}, false)
 		if err != nil {
 			tx.Rollback()
 			log.Println("ChainFollower: rollBackChainStateToPos: cannot UpdateChainState:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
 		err = tx.Commit()
 		if err != nil {
 			log.Println("ChainFollower: rollBackChainStateToPos: cannot commit DB transaction:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
 		return // success.
@@ -342,18 +389,18 @@ func (c *ChainFollower) commitChainState(tx giga.StoreTransaction, pos ChainPos)
 	err := tx.UpdateChainState(giga.ChainState{
 		BestBlockHash:   pos.BlockHash,
 		BestBlockHeight: pos.BlockHeight,
-	})
+	}, false)
 	if err != nil {
 		tx.Rollback()
 		log.Println("ChainFollower: commitChainState: cannot UpdateChainState:", err)
-		c.sleepForRetry(err)
+		c.sleepForRetry(err, 0)
 		return false // retry.
 	}
 	// Commit the entire transaction with all changes in the batch.
 	err = tx.Commit()
 	if err != nil {
 		log.Println("ChainFollower: commitChainState: cannot commit DB transaction:", err)
-		c.sleepForRetry(err)
+		c.sleepForRetry(err, 0)
 		return false // retry.
 	}
 	return true // committed.
@@ -375,7 +422,7 @@ func (c *ChainFollower) processBlock(tx giga.StoreTransaction, block giga.RpcBlo
 				accountID, scriptAddress, err := tx.MarkUTXOSpent(vin.TxID, vin.VOut, block.Height)
 				if err != nil {
 					log.Println("ChainFollower: processBlock: cannot mark UTXO in DB:", err, vin.TxID, vin.VOut)
-					c.sleepForRetry(err)
+					c.sleepForRetry(err, 0)
 					return nil // retry.
 				}
 				if accountID != "" {
@@ -406,7 +453,7 @@ func (c *ChainFollower) processBlock(tx giga.StoreTransaction, block giga.RpcBlo
 							//log.Println("ChainFollower: no account matches new UTXO:", txn_id, vout.N)
 						} else {
 							log.Println("ChainFollower: processBlock: cannot query FindAccountForAddress in DB:", err, pkhAddress)
-							c.sleepForRetry(err)
+							c.sleepForRetry(err, 0)
 							return nil // retry.
 						}
 					} else {
@@ -414,7 +461,7 @@ func (c *ChainFollower) processBlock(tx giga.StoreTransaction, block giga.RpcBlo
 						err = tx.CreateUTXO(txn_id, vout.N, vout.Value, scriptType, pkhAddress, accountID, keyIndex, isInternal, block.Height)
 						if err != nil {
 							log.Println("ChainFollower: processBlock: cannot create UTXO in DB:", err, txn_id, vout.N)
-							c.sleepForRetry(err)
+							c.sleepForRetry(err, 0)
 							return nil // retry.
 						}
 					}
@@ -452,7 +499,7 @@ func (c *ChainFollower) beginStoreTxn() (tx giga.StoreTransaction) {
 		tx, err := c.store.Begin()
 		if err != nil {
 			log.Println("ChainFollower: beginStoreTxn: cannot begin:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
 		c.tx = tx
@@ -483,7 +530,7 @@ func (c *ChainFollower) fetchChainState() giga.ChainState {
 				return giga.ChainState{} // empty chainstate.
 			}
 			log.Println("ChainFollower: error retrieving best block:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 		} else {
 			return state
 		}
@@ -495,7 +542,7 @@ func (c *ChainFollower) fetchBlock(blockHash string) giga.RpcBlock {
 		block, err := c.l1.GetBlock(blockHash)
 		if err != nil {
 			log.Println("ChainFollower: error retrieving block:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 		} else {
 			return block
 		}
@@ -507,41 +554,55 @@ func (c *ChainFollower) fetchBlockHeader(blockHash string) giga.RpcBlockHeader {
 		block, err := c.l1.GetBlockHeader(blockHash)
 		if err != nil {
 			log.Println("ChainFollower: error retrieving block header:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 		} else {
 			return block
 		}
 	}
 }
 
-// func (c *ChainFollower) fetchBlockHash(height int64) (string, error) {
-// 	for {
-// 		hash, err := c.l1.GetBlockHash(height)
-// 		if err != nil {
-// 			log.Println("ChainFollower: error retrieving block hash:", err)
-// 			c.sleepForRetry(err)
-// 		} else {
-// 			return hash, nil
-// 		}
-// 	}
-// }
+func (c *ChainFollower) fetchBlockHash(height int64) string {
+	for {
+		hash, err := c.l1.GetBlockHash(height)
+		if err != nil {
+			log.Println("ChainFollower: error retrieving block hash:", err)
+			c.sleepForRetry(err, 0)
+		} else {
+			return hash
+		}
+	}
+}
+
+func (c *ChainFollower) fetchBlockCount() int64 {
+	for {
+		count, err := c.l1.GetBlockCount()
+		if err != nil {
+			log.Println("ChainFollower: error retrieving block count:", err)
+			c.sleepForRetry(err, 0)
+		} else {
+			return count
+		}
+	}
+}
 
 func (c *ChainFollower) fetchTransaction(txHash string) giga.RawTxn {
 	for {
 		txn, err := c.l1.GetTransaction(txHash)
 		if err != nil {
 			log.Println("ChainFollower: error retrieving transaction:", err)
-			c.sleepForRetry(err)
+			c.sleepForRetry(err, 0)
 		} else {
 			return txn
 		}
 	}
 }
 
-func (c *ChainFollower) sleepForRetry(err error) {
-	delay := RETRY_DELAY
-	if giga.IsDBConflictError(err) {
-		delay = CONFLICT_DELAY
+func (c *ChainFollower) sleepForRetry(err error, delay time.Duration) {
+	if delay == 0 {
+		delay = RETRY_DELAY
+		if giga.IsDBConflictError(err) {
+			delay = CONFLICT_DELAY
+		}
 	}
 	select {
 	case cmd := <-c.Commands:

--- a/pkg/chaintracker/tipchaser.go
+++ b/pkg/chaintracker/tipchaser.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	expectedBlockInterval = 30 * time.Second
+	expectedBlockInterval = 90 * time.Second
 )
 
 type TipSubscription struct {

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -132,6 +132,11 @@ func (l L1CoreRPC) GetBestBlockHash() (blockHash string, err error) {
 	return
 }
 
+func (l L1CoreRPC) GetBlockCount() (blockCount int64, err error) {
+	err = l.request("getblockcount", []any{}, &blockCount)
+	return
+}
+
 func (l L1CoreRPC) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
 	decode := true // to get back JSON rather than HEX
 	err = l.request("getrawtransaction", []any{txnHash, decode}, &txn)

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -23,6 +23,7 @@ type L1 interface {
 	GetBlockHeader(blockHash string) (RpcBlockHeader, error)
 	GetBlockHash(height int64) (string, error)
 	GetBestBlockHash() (string, error)
+	GetBlockCount() (int64, error)
 	GetTransaction(txnHash string) (RawTxn, error)
 	Send(NewTxn) error
 	//SignMessage([]byte, Privkey) (string, error)

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -46,7 +46,7 @@ type UTXO struct {
 	Status        string     // 'p' = receive pending; 'c' = receive confirmed; 's' = spent pending; 'x' = spent confirmed
 	Value         CoinAmount // value of the txn output in dogecoin
 	ScriptType    string     // 'p2pkh', 'multisig', etc (by pattern-matching the txn output script code)
-	ScriptAddress string     // the P2PKH address required to spend the txn output (extracted from the script code)
+	ScriptAddress Address    // the P2PKH address required to spend the txn output (extracted from the script code)
 }
 
 // UTXOIterator is used to iterate over UTXOs in the Account.

--- a/pkg/dogecoin/libdogecoin.go
+++ b/pkg/dogecoin/libdogecoin.go
@@ -149,6 +149,13 @@ func (l L1Libdogecoin) GetBestBlockHash() (blockHash string, err error) {
 	return "", fmt.Errorf("not implemented")
 }
 
+func (l L1Libdogecoin) GetBlockCount() (blockCount int64, err error) {
+	if l.fallback != nil {
+		return l.fallback.GetBlockCount()
+	}
+	return 0, fmt.Errorf("not implemented")
+}
+
 func (l L1Libdogecoin) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
 	if l.fallback != nil {
 		return l.fallback.GetTransaction(txnHash)

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -48,6 +48,10 @@ func (l L1Mock) GetBestBlockHash() (blockHash string, err error) {
 	return "", fmt.Errorf("not implemented")
 }
 
+func (l L1Mock) GetBlockCount() (blockCount int64, err error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
 func (l L1Mock) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
 	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -122,47 +122,14 @@ type StoreTransaction interface {
 	IndexAddresses(entries []AddressBlock) error
 }
 
-// Create Account: foreignID must not exist.
-type CreateAccount struct {
-	Account Account
-}
-
-// Update Account: foreignID must already exist.
-type UpdateAccount struct {
-	Account Account
-}
-
-// Update: next external key numbers in an Account.
-type UpdateAccountNextExternal struct {
-	Address  Address
-	KeyIndex uint32
-}
-
-// Upsert: Invoice, unconditional.
-type UpsertInvoice struct {
-	Invoice Invoice
-}
-
-// MarkInvoiceAsPaid marks the invoice with the given ID as paid.
-// Update, unconditional.
-type MarkInvoiceAsPaid struct {
-	InvoiceID Address
-}
-
 type ChainState struct {
 	BestBlockHash   string
 	BestBlockHeight int64
 }
 
-type InsertUTXO struct {
 }
 
-type InsertUTXOAddress struct {
-	Addr   Address
-	TxHash string
-	Index  uint32
-}
-
+// Address Index: mapping from one Address to many BlockHeight (experimental)
 type AddressBlock struct {
 	Addr   Address
 	Height int64

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -115,11 +115,6 @@ type StoreTransaction interface {
 	// time a new block is processed, i.e. blockHeight increases, but it is safe to
 	// call less often (e.g. after a batch of blocks)
 	ConfirmUTXOs(confirmations int, blockHeight int64) error
-
-	// Insert (address,block-height) pairs into the Address Index.
-	// The Address Index is used to find all Blocks that contain an Address.
-	// Duplicates will be ignored.
-	IndexAddresses(entries []AddressBlock) error
 }
 
 // Current chainstate in the database.
@@ -130,10 +125,4 @@ type ChainState struct {
 	FirstHeight     int64  // block height when gigawallet first started to sync this blockchain.
 	BestBlockHash   string // last block processed by gigawallet (effects included in DB)
 	BestBlockHeight int64  // last block height processed by gigawallet (effects included in DB)
-}
-
-// Address Index: mapping from one Address to many BlockHeight (experimental)
-type AddressBlock struct {
-	Addr   Address
-	Height int64
 }

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -68,6 +68,10 @@ type StoreTransaction interface {
 	// It returns giga.NotFound if the account does not exist (key: ForeignID)
 	GetAccount(foreignID string) (Account, error)
 
+	// GetAccount returns the account with the given ID.
+	// It returns giga.NotFound if the account does not exist (key: ID)
+	GetAccountByID(ID string) (Account, error)
+
 	// Find the accountID (HD root PKH) that owns the given Dogecoin address.
 	// Also find the key index of `pkhAddress` within the HD wallet.
 	FindAccountForAddress(pkhAddress Address) (accountID Address, keyIndex uint32, isInternal bool, err error)

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -92,7 +92,7 @@ type StoreTransaction interface {
 	MarkInvoiceAsPaid(address Address) error
 
 	// UpdateChainState updates the Best Block information (checkpoint for restart)
-	UpdateChainState(state ChainState) error
+	UpdateChainState(state ChainState, writeRoot bool) error
 
 	// RevertUTXOsAboveHeight clears chain-heights above the given height recorded in UTXOs.
 	// This serves to roll back the effects of adding or spending those UTXOs.
@@ -122,11 +122,14 @@ type StoreTransaction interface {
 	IndexAddresses(entries []AddressBlock) error
 }
 
+// Current chainstate in the database.
+// Gigawallet TRANSACTIONALLY moves ChainState forward in batches of blocks,
+// updating UTXOs, Invoices and Account Balances in the same DB transaction.
 type ChainState struct {
-	BestBlockHash   string
-	BestBlockHeight int64
-}
-
+	RootHash        string // hash of block at height 1 on the chain being sync'd.
+	FirstHeight     int64  // block height when gigawallet first started to sync this blockchain.
+	BestBlockHash   string // last block processed by gigawallet (effects included in DB)
+	BestBlockHeight int64  // last block height processed by gigawallet (effects included in DB)
 }
 
 // Address Index: mapping from one Address to many BlockHeight (experimental)

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS account (
 	payout_frequency TEXT NOT NULL,
 	chain_seq INTEGER NOT NULL DEFAULT 0
 );
+CREATE INDEX IF NOT EXISTS account_foreign_i ON account (foreign_id);
 
 CREATE TABLE IF NOT EXISTS account_address (
 	address TEXT NOT NULL PRIMARY KEY,
@@ -74,6 +75,8 @@ CREATE TABLE IF NOT EXISTS utxo (
 	PRIMARY KEY (txn_id, vout)
 );
 CREATE INDEX IF NOT EXISTS utxo_account_i ON utxo (account_address);
+CREATE INDEX IF NOT EXISTS utxo_added_i ON utxo (adding_height, available_height);
+CREATE INDEX IF NOT EXISTS utxo_spent_i ON utxo (spending_height, spent_height);
 
 CREATE TABLE IF NOT EXISTS chainstate (
 	best_hash TEXT NOT NULL,
@@ -456,6 +459,23 @@ func (t SQLiteStoreTransaction) GetAccount(foreignID string) (giga.Account, erro
 	return acc, nil
 }
 
+func (t SQLiteStoreTransaction) GetAccountByID(ID string) (giga.Account, error) {
+	row := t.tx.QueryRow("SELECT foreign_id,address,privkey,next_int_key,next_ext_key,next_pool_int,next_pool_ext,payout_address,payout_threshold,payout_frequency FROM account WHERE address = ?", ID)
+	var acc giga.Account
+	err := row.Scan(
+		&acc.ForeignID, &acc.Address, &acc.Privkey,
+		&acc.NextInternalKey, &acc.NextExternalKey,
+		&acc.NextPoolInternal, &acc.NextPoolExternal,
+		&acc.PayoutAddress, &acc.PayoutThreshold, &acc.PayoutFrequency) // common (see updateAccount)
+	if err == sql.ErrNoRows {
+		return giga.Account{}, giga.NewErr(giga.NotFound, "account not found: %s", ID)
+	}
+	if err != nil {
+		return giga.Account{}, dbErr(err, "GetAccount: row.Scan")
+	}
+	return acc, nil
+}
+
 func (t SQLiteStoreTransaction) FindAccountForAddress(address giga.Address) (giga.Address, uint32, bool, error) {
 	row := t.tx.QueryRow("SELECT account_address,key_index,is_internal FROM account_address WHERE address = ?", address)
 	var accountID giga.Address
@@ -512,12 +532,7 @@ func (t SQLiteStoreTransaction) MarkInvoiceAsPaid(address giga.Address) error {
 }
 
 func (t SQLiteStoreTransaction) UpdateChainState(state giga.ChainState) error {
-	stmt, err := t.tx.Prepare("UPDATE chainstate SET best_hash = ?, best_height = ?")
-	if err != nil {
-		return dbErr(err, "UpdateChainState: preparing update")
-	}
-	defer stmt.Close()
-	res, err := stmt.Exec(state.BestBlockHash, state.BestBlockHeight)
+	res, err := t.tx.Exec("UPDATE chainstate SET best_hash=$1, best_height=$2", state.BestBlockHash, state.BestBlockHeight)
 	if err != nil {
 		return dbErr(err, "UpdateChainState: executing update")
 	}
@@ -527,12 +542,7 @@ func (t SQLiteStoreTransaction) UpdateChainState(state giga.ChainState) error {
 	}
 	if num_rows < 1 {
 		// this is the first call to UpdateChainState: insert the row.
-		stmt, err := t.tx.Prepare("INSERT INTO chainstate (best_hash, best_height) VALUES (?, ?)")
-		if err != nil {
-			return dbErr(err, "UpdateChainState: preparing insert")
-		}
-		defer stmt.Close()
-		_, err = stmt.Exec(state.BestBlockHash, state.BestBlockHeight)
+		_, err = t.tx.Exec("INSERT INTO chainstate (best_hash, best_height) VALUES ($1,$2)", state.BestBlockHash, state.BestBlockHeight)
 		if err != nil {
 			return dbErr(err, "UpdateChainState: executing insert")
 		}
@@ -541,12 +551,9 @@ func (t SQLiteStoreTransaction) UpdateChainState(state giga.ChainState) error {
 }
 
 func (t SQLiteStoreTransaction) CreateUTXO(txID string, vOut int64, value giga.CoinAmount, scriptType string, pkhAddress giga.Address, accountID giga.Address, keyIndex uint32, isInternal bool, blockHeight int64) error {
-	stmt, err := t.tx.Prepare("INSERT INTO utxo (txn_id, vout, account_address, value, script_type, script_address, key_index, is_internal, adding_height) VALUES (?,?,?,?,?,?,?,?,?)")
-	if err != nil {
-		return dbErr(err, "CreateUTXO: preparing insert")
-	}
-	defer stmt.Close()
-	_, err = stmt.Exec(txID, vOut, accountID, value, scriptType, pkhAddress, keyIndex, isInternal, blockHeight)
+	// psql: "ON CONFLICT ON CONSTRAINT utxo_pkey DO"
+	_, err := t.tx.Exec("INSERT INTO utxo (txn_id, vout, account_address, value, script_type, script_address, key_index, is_internal, adding_height) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) ON CONFLICT DO UPDATE SET account_address=$3, value=$4, script_type=$5, script_address=$6, key_index=$7, is_internal=$8, adding_height=$9 WHERE txn_id=$1 AND vout=$2",
+		txID, vOut, accountID, value, scriptType, pkhAddress, keyIndex, isInternal, blockHeight)
 	if err != nil {
 		return dbErr(err, "CreateUTXO: executing insert")
 	}
@@ -555,7 +562,7 @@ func (t SQLiteStoreTransaction) CreateUTXO(txID string, vOut int64, value giga.C
 
 func (t SQLiteStoreTransaction) MarkUTXOSpent(txID string, vOut int64, blockHeight int64) (string, error) {
 	var id string
-	rows, err := t.tx.Query("UPDATE utxo SET spending_height = ? WHERE txn_id = ? AND vout = ? RETURNING account_address", blockHeight, txID, vOut)
+	rows, err := t.tx.Query("UPDATE utxo SET spending_height=$1 WHERE txn_id=$2 AND vout=$3 RETURNING account_address", blockHeight, txID, vOut)
 	if err != nil {
 		return "", dbErr(err, "MarkUTXOSpent: executing update")
 	}
@@ -613,43 +620,61 @@ func (t SQLiteStoreTransaction) IncAccountsAffectedByRollback(maxValidHeight int
 	return ids, err
 }
 
+func (t SQLiteStoreTransaction) ConfirmUTXOs(confirmations int, blockHeight int64) error {
+	stmt, err := t.tx.Prepare("UPDATE account SET incoming=incoming-$2, balance=balance+$2 WHERE address=$1")
+	if err != nil {
+		return dbErr(err, "ConfirmUTXOs: preparing update")
+	}
+	defer stmt.Close()
+	confirmedHeight := blockHeight - int64(confirmations) // from config.
+	// note: there is an index on (adding_height, available_height) for this query.
+	// note: this uses num-confirmations from the invoice being paid, if there is one.
+	// note: this MUST be a LEFT OUTER join (script_address may not match any invoice)
+	rows, err := t.tx.Query(`
+		UPDATE utxo SET available_height=$1
+		WHERE adding_height <= COALESCE((SELECT $1 - confirmations from invoice WHERE invoice_address = utxo.script_address), $2)
+		AND available_height = NULL
+		RETURNING account_address, value
+	`, blockHeight, confirmedHeight)
+	if err != nil {
+		return dbErr(err, "ConfirmUTXOs: updating utxos")
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var value string
+		err := rows.Scan(&id, &value)
+		if err != nil {
+			return dbErr(err, "ConfirmUTXOs: scanning row")
+		}
+		stmt.Exec(id, value)
+		if err != nil {
+			return dbErr(err, "ConfirmUTXOs: updating account "+id)
+		}
+	}
+	if err = rows.Err(); err != nil { // docs say this check is required!
+		return dbErr(err, "ConfirmUTXOs: scanning rows")
+	}
+	return nil
+}
+
 func (t SQLiteStoreTransaction) RevertUTXOsAboveHeight(maxValidHeight int64) error {
-	// The presence of a height in adding_height, available_height, spending_height or spent_height
+	// The presence of a height in adding_height, available_height, spending_height, spent_height
 	// indicates that the UTXO is in the process of being added, or has been added (confirmed); is
 	// reserved for spending, or has been spent (confirmed)
-	stmt1, err := t.tx.Prepare("UPDATE utxo SET adding_height = NULL, available_height = NULL, spending_height = NULL, spent_height = NULL WHERE adding_height > ?")
-	if err != nil {
-		return dbErr(err, "RevertUTXOsAboveHeight: preparing update 1")
-	}
-	defer stmt1.Close()
-	stmt2, err := t.tx.Prepare("UPDATE utxo SET available_height = NULL, spending_height = NULL, spent_height = NULL WHERE available_height > ?")
-	if err != nil {
-		return dbErr(err, "RevertUTXOsAboveHeight: preparing update 2")
-	}
-	defer stmt2.Close()
-	stmt3, err := t.tx.Prepare("UPDATE utxo SET spending_height = NULL, spent_height = NULL WHERE spending_height > ?")
-	if err != nil {
-		return dbErr(err, "RevertUTXOsAboveHeight: preparing update 3")
-	}
-	defer stmt3.Close()
-	stmt4, err := t.tx.Prepare("UPDATE utxo SET spent_height = NULL WHERE spent_height > ?")
-	if err != nil {
-		return dbErr(err, "RevertUTXOsAboveHeight: preparing update 4")
-	}
-	defer stmt4.Close()
-	_, err = stmt1.Exec(maxValidHeight)
+	_, err := t.tx.Exec("UPDATE utxo SET adding_height=NULL,available_height=NULL,spending_height=NULL,spent_height=NULL WHERE adding_height > ?", maxValidHeight)
 	if err != nil {
 		return dbErr(err, "RevertUTXOsAboveHeight: executing update 1")
 	}
-	_, err = stmt2.Exec(maxValidHeight)
+	_, err = t.tx.Exec("UPDATE utxo SET available_height=NULL,spending_height,spent_height=NULL WHERE available_height > ?", maxValidHeight)
 	if err != nil {
 		return dbErr(err, "RevertUTXOsAboveHeight: executing update 2")
 	}
-	_, err = stmt3.Exec(maxValidHeight)
+	_, err = t.tx.Exec("UPDATE utxo SET spending_height,spent_height=NULL WHERE spending_height > ?", maxValidHeight)
 	if err != nil {
 		return dbErr(err, "RevertUTXOsAboveHeight: executing update 3")
 	}
-	_, err = stmt4.Exec(maxValidHeight)
+	_, err = t.tx.Exec("UPDATE utxo SET spent_height=NULL WHERE spent_height > ?", maxValidHeight)
 	if err != nil {
 		return dbErr(err, "RevertUTXOsAboveHeight: executing update 4")
 	}
@@ -659,21 +684,11 @@ func (t SQLiteStoreTransaction) RevertUTXOsAboveHeight(maxValidHeight int64) err
 func (t SQLiteStoreTransaction) RevertTxnsAboveHeight(maxValidHeight int64) error {
 	// The presence of a height in on_chain_height or verified_height indicates
 	// that the invoice is in a block (on-chain) or has been verified (N blocks later)
-	stmt1, err := t.tx.Prepare("UPDATE txn SET on_chain_height = NULL, verified_height = NULL WHERE on_chain_height > ?")
-	if err != nil {
-		return dbErr(err, "RevertTxnsAboveHeight: preparing update 1")
-	}
-	defer stmt1.Close()
-	stmt2, err := t.tx.Prepare("UPDATE txn SET verified_height = NULL WHERE verified_height > ?")
-	if err != nil {
-		return dbErr(err, "RevertTxnsAboveHeight: preparing update 2")
-	}
-	defer stmt2.Close()
-	_, err = stmt1.Exec(maxValidHeight)
+	_, err := t.tx.Exec("UPDATE txn SET on_chain_height = NULL, verified_height = NULL WHERE on_chain_height > ?", maxValidHeight)
 	if err != nil {
 		return dbErr(err, "RevertTxnsAboveHeight: executing update 1")
 	}
-	_, err = stmt2.Exec(maxValidHeight)
+	_, err = t.tx.Exec("UPDATE txn SET on_chain_height = NULL, verified_height = NULL WHERE on_chain_height > ?", maxValidHeight)
 	if err != nil {
 		return dbErr(err, "RevertTxnsAboveHeight: executing update 2")
 	}


### PR DESCRIPTION
Begins syncing to Core Node on first start, near the Tip of the blockchain.
Checks if the blockchain has changed (main/test) on each startup.
Keeps track of where we started syncing, for later wallet imports.

Fixed CreateUTXO conflicts when trying to re-insert a UTXO that was previously rolled back in a fork.

Experimental Address Index (turned off)
