### PR TITLE
Calculate Account Balance upon request

### DIFF
--- a/pkg/account.go
+++ b/pkg/account.go
@@ -23,6 +23,9 @@ type Account struct {
 	PayoutAddress    string
 	PayoutThreshold  string
 	PayoutFrequency  string
+	IncomingBalance  CoinAmount // pending coins being received (waiting for Txn to be confirmed)
+	CurrentBalance   CoinAmount // current balance available to spend now
+	OutgoingBalance  CoinAmount // spent funds that are not yet confirmed (waiting for Txn to be confirmed)
 }
 
 // Generate and store HD Wallet addresses up to 20 beyond any currently-used addresses.

--- a/pkg/account.go
+++ b/pkg/account.go
@@ -23,9 +23,13 @@ type Account struct {
 	PayoutAddress    string
 	PayoutThreshold  string
 	PayoutFrequency  string
-	IncomingBalance  CoinAmount // pending coins being received (waiting for Txn to be confirmed)
-	CurrentBalance   CoinAmount // current balance available to spend now
-	OutgoingBalance  CoinAmount // spent funds that are not yet confirmed (waiting for Txn to be confirmed)
+}
+
+// AccountBalance holds the current account balances for an Account.
+type AccountBalance struct {
+	IncomingBalance CoinAmount // pending coins being received (waiting for Txn to be confirmed)
+	CurrentBalance  CoinAmount // current balance available to spend now
+	OutgoingBalance CoinAmount // spent funds that are not yet confirmed (waiting for Txn to be confirmed)
 }
 
 // Generate and store HD Wallet addresses up to 20 beyond any currently-used addresses.

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -4,11 +4,6 @@ import (
 	"fmt"
 )
 
-const (
-	scriptTypeP2PKH    = "p2pkh"
-	scriptTypeMultiSig = "multisig"
-)
-
 type API struct {
 	Store    Store
 	L1       L1

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -30,7 +30,7 @@ func (a API) CreateInvoice(request InvoiceCreateRequest, foreignID string) (Invo
 	}
 	defer txn.Rollback()
 
-	acc, err := txn.GetAccount(foreignID)
+	acc, err := txn.GetAccount(foreignID, false)
 	if err != nil {
 		a.bus.Send(SYS_ERR, fmt.Sprintf("CreateInvoice: Failed to find Account: %s", foreignID))
 		return Invoice{}, err
@@ -92,7 +92,7 @@ type ListInvoicesResponse struct {
 }
 
 func (a API) ListInvoices(foreignID string, cursor int, limit int) (ListInvoicesResponse, error) {
-	acc, err := a.Store.GetAccount(foreignID)
+	acc, err := a.Store.GetAccount(foreignID, false)
 	if err != nil {
 		return ListInvoicesResponse{}, err
 	}
@@ -120,7 +120,7 @@ func (a API) CreateAccount(foreignID string, upsert bool) (AccountPublic, error)
 		}
 		defer txn.Rollback()
 
-		acc, err := txn.GetAccount(foreignID)
+		acc, err := txn.GetAccount(foreignID, false)
 		if err == nil {
 			// Account already exists.
 			if upsert {
@@ -171,7 +171,7 @@ func (a API) CreateAccount(foreignID string, upsert bool) (AccountPublic, error)
 }
 
 func (a API) GetAccount(foreignID string) (AccountPublic, error) {
-	acc, err := a.Store.GetAccount(foreignID)
+	acc, err := a.Store.GetAccount(foreignID, false)
 	if err != nil {
 		return AccountPublic{}, err
 	}
@@ -187,7 +187,7 @@ func (a API) UpdateAccountSettings(foreignID string, update map[string]interface
 	}
 	defer txn.Rollback()
 
-	acc, err := txn.GetAccount(foreignID)
+	acc, err := txn.GetAccount(foreignID, false)
 	if err != nil {
 		return AccountPublic{}, err
 	}
@@ -224,7 +224,7 @@ func (a API) PayInvoiceFromAccount(invoiceID Address, accountID string) (string,
 	if err != nil {
 		return "", err
 	}
-	payFrom, err := a.Store.GetAccount(accountID)
+	payFrom, err := a.Store.GetAccount(accountID, false)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/chaintracker/chainfollower.go
+++ b/pkg/chaintracker/chainfollower.go
@@ -174,13 +174,13 @@ func (c *ChainFollower) fetchStartingPos() ChainPos {
 			}, true)
 			if err != nil {
 				tx.Rollback()
-				log.Println("ChainFollower: fetchStartingPos: cannot UpdateChainState:", err)
+				log.Println("ChainFollower: fetchStartingPos: UpdateChainState:", err)
 				c.sleepForRetry(err, 0)
 				continue // retry.
 			}
 			err = tx.Commit()
 			if err != nil {
-				log.Println("ChainFollower: fetchStartingPos: cannot commit DB transaction:", err)
+				log.Println("ChainFollower: fetchStartingPos: cannot commit:", err)
 				c.sleepForRetry(err, 0)
 				continue // retry.
 			}
@@ -257,7 +257,7 @@ func (c *ChainFollower) transactionalRollForward(pos ChainPos) ChainPos {
 		if block.Confirmations != -1 {
 			// Still on-chain, so update chainstate from block transactions.
 			if !c.processBlock(tx, block, affectedAcconts) {
-				// Unable to process the block - roll back.
+				// Unable to process the block (error already logged) - roll back.
 				tx.Rollback()
 				return startPos
 			}
@@ -336,7 +336,7 @@ func (c *ChainFollower) rollBackChainStateToPos(pos ChainPos) {
 		_, err := tx.IncAccountsAffectedByRollback(maxValidHeight)
 		if err != nil {
 			tx.Rollback()
-			log.Println("ChainFollower: rollBackChainStateToPos: cannot IncAccountsAffectedByRollback:", err)
+			log.Println("ChainFollower: IncAccountsAffectedByRollback:", err)
 			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
@@ -344,14 +344,14 @@ func (c *ChainFollower) rollBackChainStateToPos(pos ChainPos) {
 		err = tx.RevertUTXOsAboveHeight(maxValidHeight)
 		if err != nil {
 			tx.Rollback()
-			log.Println("ChainFollower: rollBackChainStateToPos: cannot RevertUTXOsAboveHeight:", err)
+			log.Println("ChainFollower: RevertUTXOsAboveHeight:", err)
 			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
 		err = tx.RevertTxnsAboveHeight(maxValidHeight)
 		if err != nil {
 			tx.Rollback()
-			log.Println("ChainFollower: rollBackChainStateToPos: cannot RevertTxnsAboveHeight:", err)
+			log.Println("ChainFollower: RevertTxnsAboveHeight:", err)
 			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
@@ -362,13 +362,13 @@ func (c *ChainFollower) rollBackChainStateToPos(pos ChainPos) {
 		}, false)
 		if err != nil {
 			tx.Rollback()
-			log.Println("ChainFollower: rollBackChainStateToPos: cannot UpdateChainState:", err)
+			log.Println("ChainFollower: UpdateChainState:", err)
 			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
 		err = tx.Commit()
 		if err != nil {
-			log.Println("ChainFollower: rollBackChainStateToPos: cannot commit DB transaction:", err)
+			log.Println("ChainFollower: cannot commit DB transaction:", err)
 			c.sleepForRetry(err, 0)
 			continue // retry.
 		}
@@ -385,14 +385,14 @@ func (c *ChainFollower) commitChainState(tx giga.StoreTransaction, pos ChainPos)
 	}, false)
 	if err != nil {
 		tx.Rollback()
-		log.Println("ChainFollower: commitChainState: cannot UpdateChainState:", err)
+		log.Println("ChainFollower: UpdateChainState:", err)
 		c.sleepForRetry(err, 0)
 		return false // retry.
 	}
 	// Commit the entire transaction with all changes in the batch.
 	err = tx.Commit()
 	if err != nil {
-		log.Println("ChainFollower: commitChainState: cannot commit DB transaction:", err)
+		log.Println("ChainFollower: cannot commit DB transaction:", err)
 		c.sleepForRetry(err, 0)
 		return false // retry.
 	}
@@ -409,70 +409,68 @@ func (c *ChainFollower) processBlock(tx giga.StoreTransaction, block giga.RpcBlo
 			if vin.TxID != "" && vin.VOut >= 0 {
 				// Mark this UTXO as spent (at this block height)
 				// • Note: a Txn cannot spend its own outputs (but it can spend outputs from previous Txns in the same block)
-				// • We only care about UTXOs that are spendable (i.e. have a positive value and an address/PKH)
 				// • We only care about UTXOs that match a wallet (i.e. we know which wallet they belong to)
-				// log.Println("ChainFollower: marking UTXO spent", vin.TxID, vin.VOut, block.Height)
 				accountID, _, err := tx.MarkUTXOSpent(vin.TxID, vin.VOut, block.Height)
 				if err != nil {
-					log.Println("ChainFollower: processBlock: cannot mark UTXO in DB:", err, vin.TxID, vin.VOut)
+					log.Println("ChainFollower: MarkUTXOSpent:", err, vin.TxID, vin.VOut)
 					c.sleepForRetry(err, 0)
 					return false // retry.
 				}
 				if accountID != "" {
+					log.Println("ChainFollower: marking UTXO spent:", vin.TxID, vin.VOut, block.Height)
 					affectedAcconts[accountID] = nil // insert in affectedAcconts.
 				}
 			}
 		}
 		for _, vout := range txn.VOut {
 			// Ignore outputs that are not spendable.
-			if vout.Value.IsPositive() && len(vout.ScriptPubKey.Addresses) > 0 {
+			if !vout.Value.IsPositive() {
+				log.Println("ChainFollower: skipping zero-value vout:", txn_id, vout.N, vout.ScriptPubKey.Type)
+				continue
+			}
+			if len(vout.ScriptPubKey.Addresses) == 1 {
 				// Create a UTXO associated with the wallet that owns the address.
-				scriptType := typeOfScript(vout.ScriptPubKey.Type)
-				if scriptType == "p2pkh" || scriptType == "p2sh" || scriptType == "p2pk" {
-					// These script-types always contain a single address.
-					// FIXME: re-encode p2pk [and p2sh] as Addresses in a consistent format.
-					pkhAddress := giga.Address(vout.ScriptPubKey.Addresses[0])
-					// Use an address-to-account index (utxo_account_i) to find the account.
-					accountID, keyIndex, isInternal, err := tx.FindAccountForAddress(pkhAddress)
-					if err != nil {
-						if giga.IsNotFoundError(err) {
-							//log.Println("ChainFollower: no account matches new UTXO:", txn_id, vout.N)
-						} else {
-							log.Println("ChainFollower: processBlock: cannot query FindAccountForAddress in DB:", err, pkhAddress)
-							c.sleepForRetry(err, 0)
-							return false // retry.
-						}
+				scriptType := giga.DecodeCoreRPCScriptType(vout.ScriptPubKey.Type)
+				// These script-types always contain a single address.
+				// FIXME: re-encode p2pk [and p2sh] as Addresses in a consistent format.
+				pkhAddress := giga.Address(vout.ScriptPubKey.Addresses[0])
+				// Use an address-to-account index (utxo_account_i) to find the account.
+				accountID, keyIndex, isInternal, err := tx.FindAccountForAddress(pkhAddress)
+				if err != nil {
+					if giga.IsNotFoundError(err) {
+						// log.Println("ChainFollower: no account matches new UTXO:", txn_id, vout.N)
 					} else {
-						affectedAcconts[string(accountID)] = nil // insert in affectedAcconts.
-						err = tx.CreateUTXO(txn_id, vout.N, vout.Value, scriptType, pkhAddress, accountID, keyIndex, isInternal, block.Height)
-						if err != nil {
-							log.Println("ChainFollower: processBlock: cannot create UTXO in DB:", err, txn_id, vout.N)
-							c.sleepForRetry(err, 0)
-							return false // retry.
-						}
+						log.Println("ChainFollower: FindAccountForAddress:", err, pkhAddress)
+						c.sleepForRetry(err, 0)
+						return false // retry.
 					}
 				} else {
-					log.Println("ChainFollower: unknown script type:", txn_id, vout.N, vout.ScriptPubKey.Type)
+					tx.CreateUTXO(giga.NewUTXO{
+						TxID:        txn_id,
+						VOut:        vout.N,
+						Value:       vout.Value,
+						ScriptType:  scriptType,
+						PKHAddress:  pkhAddress,
+						AccountID:   accountID,
+						KeyIndex:    keyIndex,
+						IsInternal:  isInternal,
+						BlockHeight: block.Height,
+					})
+					affectedAcconts[string(accountID)] = nil // insert in affectedAcconts.
+					if err != nil {
+						log.Println("ChainFollower: CreateUTXO:", err, txn_id, vout.N)
+						c.sleepForRetry(err, 0)
+						return false // retry.
+					}
 				}
+			} else if len(vout.ScriptPubKey.Addresses) < 1 {
+				log.Println("ChainFollower: skipping no-address vout:", txn_id, vout.N, vout.ScriptPubKey.Type)
 			} else {
-				log.Println("ChainFollower: no value or no address:", txn_id, vout.N, vout.ScriptPubKey.Type)
+				log.Println("ChainFollower: skipping multi-address vout:", txn_id, vout.N, vout.ScriptPubKey.Type)
 			}
 		}
 	}
 	return true
-}
-
-func typeOfScript(name string) string {
-	if name == "pubkeyhash" {
-		return "p2pkh"
-	}
-	if name == "scripthash" {
-		return "p2sh"
-	}
-	if name == "pubkey" {
-		return "p2pk"
-	}
-	return name
 }
 
 func (c *ChainFollower) beginStoreTxn() (tx giga.StoreTransaction) {
@@ -484,7 +482,7 @@ func (c *ChainFollower) beginStoreTxn() (tx giga.StoreTransaction) {
 	for {
 		tx, err := c.store.Begin()
 		if err != nil {
-			log.Println("ChainFollower: beginStoreTxn: cannot begin:", err)
+			log.Println("ChainFollower: beginStoreTxn:", err)
 			c.sleepForRetry(err, 0)
 			continue // retry.
 		}

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -6,7 +6,10 @@ type Store interface {
 	Begin() (StoreTransaction, error)
 
 	// GetAccount returns the account with the given ForeignID.
-	GetAccount(foreignID string, calculateBalance bool) (Account, error)
+	GetAccount(foreignID string) (Account, error)
+
+	// CalculateBalance queries across UTXOs to calculate account balances.
+	CalculateBalance(accountID Address) (AccountBalance, error)
 
 	// GetInvoice returns the invoice with the given ID.
 	GetInvoice(id Address) (Invoice, error)
@@ -38,11 +41,14 @@ type StoreTransaction interface {
 
 	// GetAccount returns the account with the given ForeignID.
 	// It returns giga.NotFound if the account does not exist (key: ForeignID)
-	GetAccount(foreignID string, calculateBalance bool) (Account, error)
+	GetAccount(foreignID string) (Account, error)
 
 	// GetAccount returns the account with the given ID.
 	// It returns giga.NotFound if the account does not exist (key: ID)
-	GetAccountByID(ID string, calculateBalance bool) (Account, error)
+	GetAccountByID(ID string) (Account, error)
+
+	// CalculateBalance queries across UTXOs to calculate account balances.
+	CalculateBalance(accountID Address) (AccountBalance, error)
 
 	// GetInvoice returns the invoice with the given ID.
 	// It returns giga.NotFound if the invoice does not exist (key: ID/address)

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -80,8 +80,6 @@ type StoreTransaction interface {
 	// Unreserved means not already being used in a pending transaction.
 	GetAllUnreservedUTXOs(account Address) ([]UTXO, error)
 
-	// Create an Unspent Transaction Output (at the given block height)
-	CreateUTXO(txID string, vOut int64, value CoinAmount, scriptType string, pkhAddress Address, accountID Address, keyIndex uint32, isInternal bool, blockHeight int64) error
 
 	// Mark an Unspent Transaction Output as spent (at the given block height)
 	// Returns the ID of the Account that can spend this UTXO, if known to Gigawallet.
@@ -94,6 +92,8 @@ type StoreTransaction interface {
 	// UpdateChainState updates the Best Block information (checkpoint for restart)
 	UpdateChainState(state ChainState, writeRoot bool) error
 
+	// Create a new Unspent Transaction Output in the database.
+	CreateUTXO(utxo NewUTXO) error
 	// RevertUTXOsAboveHeight clears chain-heights above the given height recorded in UTXOs.
 	// This serves to roll back the effects of adding or spending those UTXOs.
 	RevertUTXOsAboveHeight(maxValidHeight int64) error
@@ -125,4 +125,17 @@ type ChainState struct {
 	FirstHeight     int64  // block height when gigawallet first started to sync this blockchain.
 	BestBlockHash   string // last block processed by gigawallet (effects included in DB)
 	BestBlockHeight int64  // last block height processed by gigawallet (effects included in DB)
+}
+
+// Used when inserting UTXOs into the database in a batch.
+type NewUTXO struct {
+	TxID        string     // UTXO key: Transaction ID (TxnID)
+	VOut        int64      // UTXO key: Transaction Output number.
+	Value       CoinAmount // Output Amount.
+	ScriptType  ScriptType // 'p2pkh' etc, see ScriptType constants.
+	PKHAddress  Address    // Pay-To address embedded in the script.
+	AccountID   Address    // Account ID that owns the Pay-To address.
+	KeyIndex    uint32     // Pay-To address index in the Account's HD Wallet.
+	IsInternal  bool       // Pay-To address is Internal or External in HD Wallet.
+	BlockHeight int64      // Block Height of the Block that contains this Txn.
 }


### PR DESCRIPTION
Calculate Account Balance upon request.

Store refactor: use common implementation functions for any Store
methods that are also StoreTransaction methods.

Use a common `getAccount` implementation for 3 interface methods.
Use a common `getInvoice` implementation for 2 interface methods.
Use a common `listInvoices` implementation for 2 interface methods.
Use a common `getAllUnreservedUTXOs` implementation for 2 interface methods.

Mark UTXOs as spendable once their confirmation height is reached.

Confirmation height either comes from the Invoice that the UTXO is
paying towards, or it comes from config for all other UTXOs.

Renamed a couple of the database fields for clarity.
Fixed bug: "IS NULL" works in SQL, "= NULL" does not.
Cleaned up Script Types, ChainFollower logging.