### PR TITLE
Vastly improved database concurrency!

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -107,6 +107,9 @@ func NewSQLiteStore(fileName string) (giga.Store, error) {
 	if err != nil {
 		return SQLiteStore{}, dbErr(err, "opening database")
 	}
+	// limit concurrent access until we figure out a way to start transactions
+	// with the BEGIN CONCURRENT statement in Go.
+	db.SetMaxOpenConns(1)
 	// WAL mode provides more concurrency
 	_, err = db.Exec("PRAGMA journal_mode=WAL")
 	if err != nil {


### PR DESCRIPTION
Discovered that ChainFollower was holding open long-running transactions while it fetched a batch of Blocks, and then fetched every single Txn in those blocks from Core via RPC.

Changed so that ChainFollower does all of this work up-front, then begins a database transaction and applies all the changes all in one go. The resulting transactions are very short, allowing a lot more time for API requests to perform their Queries and transactions.

Also found a work-around for "database is locked" errors in SQLite: by using `db.SetMaxOpenConns(1)` to limit the number of concurrent connections, it means all attempts to Begin() a transaction will queue up and wait their turn, instead of attempting the transaction and getting a "database is locked" error.

Obviously for Postgres we don't want this limit, but for SQLite we do.