### PR TITLE
Split the API between two ports, admin and private

### DIFF
--- a/cmd/gigawallet/commands.go
+++ b/cmd/gigawallet/commands.go
@@ -46,11 +46,11 @@ func adminAPIURL(c giga.Config, s SubCommandArgs, path string) (string, error) {
 	if s.RemoteAdminServer != "" {
 		base = s.RemoteAdminServer
 	} else {
-		host := c.WebAPI.Bind
+		host := c.WebAPI.AdminBind
 		if host == "" {
 			host = "localhost"
 		}
-		base = fmt.Sprintf("http://%s:%s/", host, c.WebAPI.Port)
+		base = fmt.Sprintf("http://%s:%s/", host, c.WebAPI.AdminPort)
 	}
 	u, err := url.Parse(base)
 	if err != nil {

--- a/cmd/gigawallet/main.go
+++ b/cmd/gigawallet/main.go
@@ -29,8 +29,11 @@ func main() {
 			RejectionsNeeded:    12,
 		},
 		WebAPI: giga.WebAPIConfig{
-			Port: "8080",
-			Bind: "localhost",
+			AdminPort:     "8081",
+			AdminBind:     "localhost",
+			PubPort:       "8082",
+			PubBind:       "localhost",
+			PubAPIRootURL: "http://localhost:8082",
 		},
 		Store: giga.StoreConfig{
 			DBFile: "gigawallet.db",
@@ -126,8 +129,10 @@ func applyFlags(config *giga.Config, subs *SubCommandArgs) {
 	flag.StringVar(&config.Gigawallet.ServiceKeyHash, "service-key-hash", config.Gigawallet.ServiceKeyHash, "Service key hash")
 	flag.StringVar(&config.Gigawallet.Network, "network", config.Gigawallet.Network, "Network")
 	flag.IntVar(&config.Gigawallet.ConfirmationsNeeded, "confirmations-needed", config.Gigawallet.ConfirmationsNeeded, "Confirmations needed")
-	flag.StringVar(&config.WebAPI.Port, "webapi-port", config.WebAPI.Port, "Web API port")
-	flag.StringVar(&config.WebAPI.Bind, "webapi-bind", config.WebAPI.Bind, "Web API bind")
+	flag.StringVar(&config.WebAPI.AdminPort, "admin-port", config.WebAPI.AdminPort, "Admin API port")
+	flag.StringVar(&config.WebAPI.AdminBind, "admin-bind", config.WebAPI.AdminBind, "Admin API bind")
+	flag.StringVar(&config.WebAPI.PubPort, "pub-port", config.WebAPI.PubPort, "Pub API port")
+	flag.StringVar(&config.WebAPI.PubBind, "pub-bind", config.WebAPI.PubBind, "Pub API bind")
 	flag.StringVar(&config.Store.DBFile, "store-db-file", config.Store.DBFile, "Store DB file")
 	// Extra arguments for various subcommands
 	flag.StringVar(&subs.RemoteAdminServer, "remote-admin-server", "", "http/s base URL for a remote GigaWallet server to command")

--- a/devconf.toml
+++ b/devconf.toml
@@ -1,8 +1,11 @@
 # This config is meant for local development only
 
 [WebAPI]
-  bind = "localhost"  # avoids macOS firewall confirmation!
-  port = "8081"
+  adminbind = "localhost"  # avoids macOS firewall confirmation!
+  adminport = "8081"
+  pubbind = "localhost"  # avoids macOS firewall confirmation!
+  pubport = "8082"
+  pubapirooturl = "http://localhost:8082"
 
 [gigawallet]
   network = "mainnet"  # which dogecoind to connect to

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -58,8 +58,14 @@ type NodeConfig struct {
 }
 
 type WebAPIConfig struct {
-	Port string
-	Bind string // optional interface IP address
+	// Admin API
+	AdminPort string
+	AdminBind string // optional interface IP address
+
+	// Public API
+	PubPort       string
+	PubBind       string // optional interface IP address
+	PubAPIRootURL string // ie: https://example.com/gigawallet
 }
 
 type StoreConfig struct {

--- a/pkg/invoice.go
+++ b/pkg/invoice.go
@@ -65,11 +65,11 @@ func (i *Invoice) Validate() error {
 		// Value should be greater than zero, unless type is discount
 		if item.Type == "discount" {
 			if item.Value.GreaterThanOrEqual(decimal.Zero) {
-				return errors.New("Discount price should be less than zero")
+				return errors.New("Discount value should be less than zero")
 			}
 		} else {
 			if item.Value.LessThanOrEqual(decimal.Zero) {
-				return errors.New("Item price should be greater than zero")
+				return errors.New("Item value should be greater than zero")
 			}
 		}
 


### PR DESCRIPTION
The purpose here is to allow firewalling of the admin API while public proxying to the public api.

The connect & qr endpoints only work on the public API server now.

Introduced new config for different webservers, as well as a new entry for the public facing root URL so that the QR code can point to the correct dogecoin connect endpoint.