### PR TITLE
Work on sending outgoing payments from Gigawallet.

### DIFF
--- a/cmd/gigawallet/server.go
+++ b/cmd/gigawallet/server.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	giga "github.com/dogecoinfoundation/gigawallet/pkg"
 	"github.com/dogecoinfoundation/gigawallet/pkg/broker"
 	"github.com/dogecoinfoundation/gigawallet/pkg/chaintracker"
@@ -15,12 +13,6 @@ import (
 )
 
 func Server(conf giga.Config) {
-
-	rpc, err := dogecoin.NewL1Libdogecoin(conf, nil)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(rpc.MakeAddress())
 
 	c := conductor.NewConductor(
 		conductor.HookSignals(),

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -93,7 +93,7 @@ func (l L1CoreRPC) request(method string, params []any, result any) error {
 	return nil
 }
 
-func (l L1CoreRPC) MakeAddress() (giga.Address, giga.Privkey, error) {
+func (l L1CoreRPC) MakeAddress(isTestNet bool) (giga.Address, giga.Privkey, error) {
 	return "", "", fmt.Errorf("not implemented")
 }
 
@@ -101,7 +101,7 @@ func (l L1CoreRPC) MakeChildAddress(privkey giga.Privkey, addressIndex uint32, i
 	return "", fmt.Errorf("not implemented")
 }
 
-func (l L1CoreRPC) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.NewTxn, error) {
+func (l L1CoreRPC) MakeTransaction(inputs []giga.UTXO, outputs []giga.NewTxOut, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.NewTxn, error) {
 	return giga.NewTxn{}, fmt.Errorf("not implemented")
 }
 
@@ -143,6 +143,6 @@ func (l L1CoreRPC) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
 	return
 }
 
-func (l L1CoreRPC) Send(txn giga.NewTxn) error {
+func (l L1CoreRPC) Send(txnHex string) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/dogecoin/libdogecoin.go
+++ b/pkg/dogecoin/libdogecoin.go
@@ -29,89 +29,132 @@ type L1Libdogecoin struct {
 	fallback giga.L1
 }
 
-func (l L1Libdogecoin) MakeAddress() (giga.Address, giga.Privkey, error) {
+func (l L1Libdogecoin) MakeAddress(isTestNet bool) (giga.Address, giga.Privkey, error) {
 	libdogecoin.W_context_start()
-	priv, pub := libdogecoin.W_generate_hd_master_pub_keypair(false)
+	priv, pub := libdogecoin.W_generate_hd_master_pub_keypair(isTestNet)
+	if priv == "" || pub == "" {
+		return "", "", giga.NewErr(giga.L1Error, "cannot generate_hd_master_pub_keypair")
+	}
 	libdogecoin.W_context_stop()
 	return giga.Address(pub), giga.Privkey(priv), nil
 }
 
-func (l L1Libdogecoin) MakeChildAddress(privkey giga.Privkey, addressIndex uint32, isInternal bool) (giga.Address, error) {
+func (l L1Libdogecoin) MakeChildAddress(privkey giga.Privkey, keyIndex uint32, isInternal bool) (giga.Address, error) {
 	libdogecoin.W_context_start()
 	// this API is a bit odd: it returns the "extended public key"
 	// which you can think of as a coordinate in the HD Wallet key-space.
-	hd_node := libdogecoin.W_get_derived_hd_address(string(privkey), 0, isInternal, addressIndex, false)
+	hd_node_pub := libdogecoin.W_get_derived_hd_address(string(privkey), 0, isInternal, keyIndex, false)
+	if hd_node_pub == "" {
+		return "", giga.NewErr(giga.L1Error, "cannot get_derived_hd_address")
+	}
 	// derive the dogecoin address (hash) from the extended public-key
-	pub := libdogecoin.W_generate_derived_hd_pub_key(hd_node)
+	pkh := libdogecoin.W_generate_derived_hd_pub_key(hd_node_pub)
+	if pkh == "" {
+		return "", giga.NewErr(giga.L1Error, "cannot generate_derived_hd_pub_key")
+	}
 	libdogecoin.W_context_stop()
-	return giga.Address(pub), nil
+	return giga.Address(pkh), nil
 }
 
-func (l L1Libdogecoin) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.NewTxn, error) {
+func (l L1Libdogecoin) MakeTransaction(inputs []giga.UTXO, outputs []giga.NewTxOut, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.NewTxn, error) {
 	libdogecoin.W_context_start()
 	defer libdogecoin.W_context_stop()
 
 	// validate transaction amounts
-	if len(UTXOs) < 1 {
-		return giga.NewTxn{}, fmt.Errorf("cannot make a txn with zero UTXOs")
+	if len(inputs) < 1 || len(outputs) < 1 {
+		return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "cannot make a txn with zero inputs or zero outputs")
 	}
 	totalIn := giga.ZeroCoins
-	for _, UTXO := range UTXOs {
-		totalIn = totalIn.Add(UTXO.Value)
+	for _, utxo := range inputs {
+		totalIn = totalIn.Add(utxo.Value)
 	}
-	minRequired := amount.Add(fee)
-	if totalIn.LessThan(minRequired) {
-		return giga.NewTxn{}, fmt.Errorf("UTXOs do not hold enough value to pay amount plus fee: %s vs %s", totalIn.String(), minRequired.String())
+	totalOut := giga.ZeroCoins
+	for _, out := range outputs {
+		totalOut = totalOut.Add(out.Amount)
+	}
+	outPlusFee := totalOut.Add(fee)
+	if totalIn.LessThan(outPlusFee) {
+		return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "inputs do not hold enough value to pay outputs plus fee: %s vs %s", totalIn.String(), outPlusFee.String())
+	}
+	if totalIn.GreaterThan(outPlusFee) {
+		return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "total inputs exceed total outputs plus fee: %s vs %s", totalIn.String(), outPlusFee.String())
 	}
 
 	// create the transaction
 	tx := libdogecoin.W_start_transaction()
 	defer libdogecoin.W_clear_transaction(tx)
 
-	// add the UTXOs to spend in the transaction
-	for _, UTXO := range UTXOs {
-		if libdogecoin.W_add_utxo(tx, UTXO.TxnID, UTXO.VOut) != 1 {
-			return giga.NewTxn{}, fmt.Errorf("libdogecoin error adding UTXO: %v", UTXO)
+	// add transaction inputs: UTXOs to spend.
+	for _, utxo := range inputs {
+		if libdogecoin.W_add_utxo(tx, utxo.TxID, utxo.VOut) != 1 {
+			return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "cannot add transaction input: %v", utxo)
 		}
 	}
 
-	// add output: P2PKH to the payTo Address
-	if libdogecoin.W_add_output(tx, string(payTo), amount.String()) != 1 {
-		return giga.NewTxn{}, fmt.Errorf("libdogecoin error adding payTo output")
+	// add transaction outputs: P2PKH paid to ScriptAddress.
+	var anyOutputAddress string
+	for _, out := range outputs {
+		if libdogecoin.W_add_output(tx, string(out.ScriptAddress), out.Amount.String()) != 1 {
+			return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "cannot add transaction output: %v", out)
+		}
+		anyOutputAddress = string(out.ScriptAddress)
 	}
 
-	// finalize the transaction: adds a change output if necessary
+	// finalize the transaction: adds a change output if necessary.
 	// the first address (destination_address) is only used to determine main-net or test-net.
 	// the final argument is the change_address which will be used to add a txn output if there is any change.
-	tx_hex := libdogecoin.W_finalize_transaction(tx, string(payTo), fee.String(), totalIn.String(), string(change))
+	tx_hex := libdogecoin.W_finalize_transaction(tx, anyOutputAddress, fee.String(), totalIn.String(), string(change))
 	if tx_hex == "" {
-		return giga.NewTxn{}, fmt.Errorf("libdogecoin error finalizing transaction")
+		return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "cannot finalize_transaction")
 	}
 
 	// FIXME: safer to extract this from the transaction output added by libdogecoin (if any)
-	change_amt := totalIn.Sub(amount).Sub(fee)
+	change_amt := totalIn.Sub(totalOut).Sub(fee)
 
-	// we have the payer's private key in WIF format.
-	// generate the payer's public P2PKH Address from the private key.
-	p2pkh_pub := libdogecoin.W_generate_derived_hd_pub_key(string(private_key_wif))
-	if p2pkh_pub == "" {
-		return giga.NewTxn{}, fmt.Errorf("libdogecoin error generating pubkey for privkey")
+	// Sign the transaction: we need to sign each input UTXO separately,
+	// because each one is generated from our HD Wallet with a different P2PKH Address.
+	for n, utxo := range inputs {
+		// Locate the HD Node in the HD Wallet for the Private Key at KeyIndex.
+		// The PK should be the key for the ScriptAddress we extracted from the UTXO.
+		hd_node_pk := libdogecoin.W_get_derived_hd_address(string(private_key_wif), 0, utxo.IsInternal, utxo.KeyIndex, true)
+		if hd_node_pk == "" {
+			return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "cannot get_derived_hd_address priv: %v", utxo)
+		}
+		hd_node_pub := libdogecoin.W_get_derived_hd_address(string(private_key_wif), 0, utxo.IsInternal, utxo.KeyIndex, false)
+		if hd_node_pub == "" {
+			return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "cannot get_derived_hd_address pub: %v", utxo)
+		}
+
+		// Problem 1:
+		// Given HD PK: dgpv5Brh8HrjmwCZVn2c4d89qvaSRbtXVhncGKzFdkxevBD48jyZ2QFPBDC5kqyGcPDFeMAZyjMxFmFEnj4PM1LQZ7GicpjqKkFWMmY7jYYkMZo
+		// How to get "privkey_wif" eg. ci5prbqz7jXyFPVWKkHhPq4a9N8Dag3TpeRfuqqC2Nfr7gSqx1fy
+
+		// Problem 2:
+		// Given HD Pub: dgub8vjpTyndL5rtnpgm6rk8xn82uAJAKppKYknTokMuiJG7go5FSAo8qWbjL88sShdBQLHn1xkAzEuqRRXPzwDJ7KNkune83STCYkXF4WqtdAc
+		// How to get "utxo_scriptpubkey" eg. 76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac
+
+		// Both of the above are required to call W_sign_raw_transaction !!
+
+		// Generate the corresponding P2PKH Address for this PK.
+		hd_p2pkh := libdogecoin.W_generate_derived_hd_pub_key(hd_node_pk)
+		if hd_p2pkh == "" {
+			return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "cannot generate_derived_hd_pub_key: %v", utxo)
+		}
+		// Verify we have the right PK for the UTXO ScriptAddress.
+		if hd_p2pkh != string(utxo.ScriptAddress) {
+			return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "HD Private Key doesn't match UTXO ScriptAddress: %v", utxo)
+		}
+
+		// sign the Nth transaction input (i.e. generate the unlocking script)
+		// [input_index, incoming_raw_tx string, script_hex string, sig_hash_type int, privkey string]
+		// "the pubkey script in hexadecimal format (scripthex)"
+		tx_hex = libdogecoin.W_sign_raw_transaction(n, tx_hex, hd_p2pkh, SIGHASH_ALL, hd_node_pk)
+		if tx_hex == "" {
+			return giga.NewTxn{}, giga.NewErr(giga.InvalidTxn, "cannot sign_raw_transaction: %v", utxo)
+		}
 	}
 
-	// sign the transaction: sign each input UTXO with our public and private key
-	// note: assumes all UTXOs were created with standard P2PKH script (no Multisig etc)
-	// and the same private key (FIXME: won't be true for HD-Wallet UTXOs)
-	if libdogecoin.W_sign_transaction(tx, p2pkh_pub, string(private_key_wif)) != 1 {
-		return giga.NewTxn{}, fmt.Errorf("libdogecoin failed to sign transaction")
-	}
-
-	// we might need to sign each input separately (if each UTXO has a different pay-to Address,
-	//                                      don't we need a different private key for each one?)
-	// for n := range UTXOs {
-	// 	tx_hex = libdogecoin.W_sign_raw_transaction(n, tx_hex, script_pubkey, SIGHASH_ALL, private_key_wif)
-	// }
-
-	return giga.NewTxn{TxnHex: tx_hex, TotalIn: totalIn, PayAmount: amount, FeeAmount: fee, ChangeAmount: change_amt}, nil
+	return giga.NewTxn{TxnHex: tx_hex, TotalIn: totalIn, TotalOut: totalOut, FeeAmount: fee, ChangeAmount: change_amt}, nil
 }
 
 func (l L1Libdogecoin) DecodeTransaction(txnHex string) (giga.RawTxn, error) {
@@ -163,9 +206,9 @@ func (l L1Libdogecoin) GetTransaction(txnHash string) (txn giga.RawTxn, err erro
 	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
-func (l L1Libdogecoin) Send(txn giga.NewTxn) error {
+func (l L1Libdogecoin) Send(txnHex string) error {
 	if l.fallback != nil {
-		return l.fallback.Send(txn)
+		return l.fallback.Send(txnHex)
 	}
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -16,7 +16,7 @@ func NewL1Mock(config giga.Config) (L1Mock, error) {
 
 type L1Mock struct{}
 
-func (l L1Mock) MakeAddress() (giga.Address, giga.Privkey, error) {
+func (l L1Mock) MakeAddress(isTestNet bool) (giga.Address, giga.Privkey, error) {
 	return "mockAddress", "mockPrivkey", nil
 }
 
@@ -24,7 +24,7 @@ func (l L1Mock) MakeChildAddress(privkey giga.Privkey, addressIndex uint32, isIn
 	return "mockChildAddress", nil
 }
 
-func (l L1Mock) MakeTransaction(amount giga.CoinAmount, UTXOs []giga.UTXO, payTo giga.Address, fee giga.CoinAmount, change giga.Address, private_key giga.Privkey) (giga.NewTxn, error) {
+func (l L1Mock) MakeTransaction(inputs []giga.UTXO, outputs []giga.NewTxOut, fee giga.CoinAmount, change giga.Address, private_key_wif giga.Privkey) (giga.NewTxn, error) {
 	return giga.NewTxn{}, fmt.Errorf("not implemented")
 }
 
@@ -56,6 +56,6 @@ func (l L1Mock) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
 	return giga.RawTxn{}, fmt.Errorf("not implemented")
 }
 
-func (l L1Mock) Send(txn giga.NewTxn) error {
+func (l L1Mock) Send(txnHex string) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -7,12 +7,15 @@ import (
 type ErrorCode string
 
 const (
-	BadRequest    ErrorCode = "bad-request"
-	NotAvailable  ErrorCode = "not-available"
-	NotFound      ErrorCode = "not-found"
-	AlreadyExists ErrorCode = "already-exists"
-	DBConflict    ErrorCode = "db-conflict"
-	UnknownError  ErrorCode = "unknown-error"
+	BadRequest        ErrorCode = "bad-request"
+	NotAvailable      ErrorCode = "not-available"
+	NotFound          ErrorCode = "not-found"
+	AlreadyExists     ErrorCode = "already-exists"
+	L1Error           ErrorCode = "libdoge-error"
+	InvalidTxn        ErrorCode = "invalid-txn"
+	InsufficientFunds ErrorCode = "insufficient-funds"
+	DBConflict        ErrorCode = "db-conflict"
+	UnknownError      ErrorCode = "unknown-error"
 )
 
 type ErrorInfo struct {

--- a/pkg/utxo.go
+++ b/pkg/utxo.go
@@ -1,0 +1,171 @@
+package giga
+
+import "github.com/shopspring/decimal"
+
+// UTXO is an Unspent Transaction Output, i.e. a prior payment into our Account.
+// This is used in the interface to Store and L1 (libdogecoin)
+type UTXO struct {
+	TxID          string     // Dogecoin Transaction ID - part of unique key (from Txn Output)
+	VOut          int        // Transaction VOut number - part of unique key (from Txn Output)
+	Value         CoinAmount // Amount of Dogecoin available to spend (from Txn Output)
+	ScriptType    ScriptType // 'p2pkh' etc, see ScriptType constants
+	ScriptAddress Address    // P2PKH address required to spend this UTXO (extracted from the script code)
+	Account       Address    // Account ID (by searching for ScriptAddress using FindAccountForAddress)
+	KeyIndex      uint32     // Account HD Wallet key-index of the ScriptAddress (needed to spend)
+	IsInternal    bool       // Account HD Wallet internal/external address flag for ScriptAddress (needed to spend)
+}
+
+// NewTxOut is an output from a new Txn, i.e. creates a new UTXO.
+type NewTxOut struct {
+	ScriptType    ScriptType // 'p2pkh' etc, see ScriptType constants
+	Amount        CoinAmount // Amount of Dogecoin to pay to the PayTo address
+	ScriptAddress Address    // Dogecoin P2PKH Address to receive the funds
+}
+
+// Composite Key for map.
+type UTXOKey struct {
+	TxID string // Transaction ID
+	VOut int    // Transaction VOut number
+}
+
+// TxnBuilder creates and signs a new Dogecoin Transaction.
+type TxnBuilder struct {
+	lib     L1               // libdogecoin library interface
+	account *Account         // POINTER to Account (uses NextChangeAddress, GenerateAddress, UpdatePoolAddresses)
+	source  *UTXOSource      // Source of UTXOs in the Account (cache; accesses the Store)
+	used    map[UTXOKey]bool // Account UTXOs already included in inputs (during building)
+	inputs  []UTXO           // Input UTXOs to spend in the Txn
+	outputs []NewTxOut       // Outputs to create (new UTXOs)
+	change  Address          // Change address (new HD Wallet internal key)
+	fee     CoinAmount       // DogeCoin amount to pay as a fee (usually derived from transaction size)
+	txn     NewTxn           // Encoded Tx Hex from libdogecoin
+}
+
+func NewTxnBuilder(account *Account, store Store, lib L1) (TxnBuilder, error) {
+	changeAddress, err := account.NextChangeAddress(lib)
+	if err != nil {
+		return TxnBuilder{}, err
+	}
+	return TxnBuilder{
+		lib:     lib,
+		account: account,
+		source:  account.GetUTXOSource(store),
+		used:    make(map[UTXOKey]bool),
+		change:  changeAddress,
+	}, nil
+}
+
+func (b *TxnBuilder) regenerateTxn() error {
+	txn, err := b.lib.MakeTransaction(b.inputs, b.outputs, b.fee, b.change, b.account.Privkey)
+	if err != nil {
+		return err
+	}
+	b.txn = txn
+	return nil
+}
+
+func (b *TxnBuilder) TotalInputs() CoinAmount {
+	totalIn := ZeroCoins
+	for _, utxo := range b.inputs {
+		totalIn = totalIn.Add(utxo.Value)
+	}
+	return totalIn
+}
+
+func (b *TxnBuilder) TotalOutputs() CoinAmount {
+	totalOut := ZeroCoins
+	for _, utxo := range b.outputs {
+		totalOut = totalOut.Add(utxo.Amount)
+	}
+	return totalOut
+}
+
+func (b *TxnBuilder) AddInput(utxo UTXO) error {
+	// UTXO must be associated with an Account and ScriptAddress so we can spend it.
+	if utxo.Account == "" || utxo.ScriptAddress == "" || utxo.Value.LessThanOrEqual(ZeroCoins) {
+		return NewErr(InvalidTxn, "invalid transaction input")
+	}
+	if !b.Includes(utxo.TxID, utxo.VOut) {
+		b.inputs = append(b.inputs, utxo)
+		b.used[UTXOKey{TxID: utxo.TxID, VOut: utxo.VOut}] = true
+	}
+	return nil
+}
+
+func (b *TxnBuilder) AddUTXOsUpToAmount(amount CoinAmount) error {
+	current := b.TotalInputs()
+	for current.LessThan(amount) {
+		utxo, err := b.source.NextUnspentUTXO(b)
+		if err == nil {
+			b.inputs = append(b.inputs, utxo)
+			b.used[UTXOKey{TxID: utxo.TxID, VOut: utxo.VOut}] = true
+			current = current.Add(utxo.Value)
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *TxnBuilder) AddOutput(payTo Address, amount CoinAmount) error {
+	if payTo == "" || amount.LessThanOrEqual(ZeroCoins) {
+		return NewErr(InvalidTxn, "invalid transaction output")
+	}
+	b.outputs = append(b.outputs, NewTxOut{
+		ScriptType:    scriptTypeP2PKH,
+		Amount:        amount,
+		ScriptAddress: payTo,
+	})
+	return nil
+}
+
+// Calculate the minimum Fee payable to mine the transaction.
+// The fee is based on the transacion size (i.e. number of inputs and outputs)
+func (b *TxnBuilder) calculateFeeForSize() (CoinAmount, error) {
+	err := b.regenerateTxn()
+	if err != nil {
+		return ZeroCoins, err
+	}
+	numBytes := decimal.NewFromInt(int64(len(b.txn.TxnHex) / 2))
+	fee := TxnFeePerByte.Mul(numBytes)
+	return fee, nil
+}
+
+// Calculate the Fee based on the size of the final signed transaction.
+// Make sure the UTXO Inputs cover that fee as well as all Outputs,
+// and add new UTXOs to cover the fee if necessary (if this happens,
+// the transaction size changes and we need to loop and go again.)
+func (b *TxnBuilder) CalculateFee(extraFee CoinAmount) error {
+	for {
+		sizeFee, err := b.calculateFeeForSize()
+		if err != nil {
+			return err
+		}
+		newTotal := b.TotalOutputs().Add(sizeFee).Add(extraFee)
+		numInputs := len(b.inputs)
+		err = b.AddUTXOsUpToAmount(newTotal)
+		if err != nil {
+			return err
+		}
+		if len(b.inputs) > numInputs {
+			// Number of inputs changed in order to pay the fee amount.
+			// This changes the size of the transaction, so go back and calculate again.
+			continue
+		}
+		// Done: current set of inputs covers the current fee.
+		b.fee = sizeFee
+		return nil
+	}
+}
+
+func (b *TxnBuilder) GetFinalTxn() (NewTxn, error) {
+	if len(b.txn.TxnHex) > 0 && b.fee.GreaterThan(ZeroCoins) {
+		return b.txn, nil
+	}
+	return NewTxn{}, NewErr(InvalidTxn, "fee has not been calculated yet")
+}
+
+// Implement UTXOSet interface.
+func (b *TxnBuilder) Includes(txID string, vOut int) bool {
+	return b.used[UTXOKey{TxID: txID, VOut: vOut}]
+}


### PR DESCRIPTION
New API:
```
POST /account/:foreignID/pay { "amount": "1.0", "to": "DPeTgZm7LabnmFTJkAPfADkwiKreEMmzio" }
```
Pays funds from an account managed by Gigawallet to a Dogecoin Address.

UTXOSource: a UTXO cache attached to the Account that fetches UTXOs from the database on demand (only local to the Account instance)

TxnBuilder: a helper to create Dogecoin Txns. Acquires UTXOs from UTXOSource in AddUTXOsUpToAmount. Also in CalculateFee, which adds a fee based on transaction size, then adds UTXOs to cover the fee if necessary (this causes a loop.)

SendFundsToAddress API: basic outgoing payment to a Doge address.
PayInvoiceFromAccount API: updated to use new TxnBuilder helper.

Encountered some problems actually signing UTXOs in MakeTransaction. It seems to need raw hex Privkey and Pubkey, but I only have Extended HD Keys in WIF (dgpv, dgub) - not sure how to convert these.

Fixed wrong query in GetAllUnreservedUTXOs.