### PR TITLE
Doge helpers: GenerateP2PKHFromECPrivKeyWIF, ECKeyIsValid

### DIFF
--- a/pkg/doge/extract.go
+++ b/pkg/doge/extract.go
@@ -1,15 +1,32 @@
 package doge
 
+import "fmt"
+
 // Given a Bip32 Extended Private Key WIF, extract the WIF-encoded EC Private Key.
-func ExtractECPrivKeyFromBip32(ext_key string) (string, error) {
-	bkey, err := DecodeBip32WIF(ext_key, nil)
+func ExtractECPrivKeyFromBip32(ext_key_wif string) (ec_privkey_wif string, err error) {
+	bkey, err := DecodeBip32WIF(ext_key_wif, nil)
 	if err != nil {
 		return "", err
 	}
 	priv, err := bkey.GetECPrivKey()
 	if err != nil {
+		bkey.Clear() // clear key for security.
 		return "", err
 	}
 	chain := ChainFromKeyBits(bkey.keyType)
+	bkey.Clear() // clear key for security.
+	if !ECKeyIsValid(priv) {
+		return "", fmt.Errorf("ExtractECPrivKeyFromBip32: invalid EC key (zero or >= N)")
+	}
 	return EncodeECPrivKeyWIF(priv, chain), nil
+}
+
+func GenerateP2PKHFromECPrivKeyWIF(ec_priv_key_wif string) (p2pkh string, err error) {
+	ec_pk, chain, err := DecodeECPrivKeyWIF(ec_priv_key_wif, nil)
+	if err != nil {
+		return "", err
+	}
+	ec_pub := ECPubKeyFromECPrivKey(ec_pk)
+	clear(ec_pk) // clear key for security.
+	return PubKeyToP2PKH(ec_pub, chain), nil
 }


### PR DESCRIPTION
GenerateP2PKHFromECPrivKeyWIF: needed this when signing transactions to double-check that the PrivKey matches the Dogecoin Address.

ECKeyIsValid: seems sensible to validate Private Keys.

Security: cleared private keys in memory whenever possible. Still room for improvement here - Go copies return values, and who knows where those copies go in memory (it would be better to pass around pointers to an ECPrivKey struct, that way we can explicitly Clear it and there are no copies to worry about.)