### PR TITLE
Postgres support: query placeholders, backend detect, error handling.

### DIFF
--- a/cmd/gigawallet/server.go
+++ b/cmd/gigawallet/server.go
@@ -36,7 +36,7 @@ func Server(conf giga.Config) {
 		panic(err)
 	}
 
-	// Setup a Store, SQLite for now
+	// Setup a Store
 	store, err := store.NewSQLiteStore(conf.Store.DBFile)
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/dogeorg/go-libdogecoin v0.0.45
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/mr-tron/base58 v1.2.0
 	github.com/pebbe/zmq4 v1.2.9

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/dogeorg/go-libdogecoin v0.0.45 h1:M4V69ho6cdE/Xw9KyLxwErC17RFHIOZrNvs
 github.com/dogeorg/go-libdogecoin v0.0.45/go.mod h1:1ByEB/S1JNzgYy3bwZfeTXf+3683dxALhmYbw4B/4B0=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-sqlite3 v1.14.14 h1:qZgc/Rwetq+MtyE18WhzjokPD93dNqLGNT3QJuLvBGw=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=

--- a/pkg/chaintracker/chainfollower.go
+++ b/pkg/chaintracker/chainfollower.go
@@ -551,7 +551,7 @@ func (c *ChainFollower) applyUTXOChanges(tx giga.StoreTransaction, changes []UTX
 }
 
 func (c *ChainFollower) processBlock(block giga.RpcBlock, changes []UTXOChange, txIDs []string) ([]UTXOChange, []string) {
-	log.Println("ChainFollower: processing block", block.Hash, block.Height)
+	log.Println("ChainFollower: processing block", block.Hash, len(block.Tx), block.Height)
 	// Insert entirely-new UTXOs that don't exist in the database.
 	for _, txn_id := range block.Tx {
 		txIDs = append(txIDs, txn_id)

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -147,12 +147,11 @@ type RpcBlock struct {
 	Bits              string          `json:"bits"`              // (string) The bits
 	Difficulty        decimal.Decimal `json:"difficulty"`        // (numeric) The difficulty
 	ChainWork         string          `json:"chainwork"`         // (string) Expected number of hashes required to produce the chain up to this block (hex)
-	NTx               int             `json:"nTx"`               // (numeric) The number of transactions in the block
 	PreviousBlockHash string          `json:"previousblockhash"` // (string) The hash of the previous block (hex)
 	NextBlockHash     string          `json:"nextblockhash"`     // (string) The hash of the next block (hex)
 }
 
-// RpcBlockHeader is decoded from hex data by L1/Core.
+// RpcBlockHeader from Core includes on-chain status (Confirmations = -1 means on a fork)
 // Derived from the `getblockheader` Core API.
 // https://developer.bitcoin.org/reference/rpc/getblockheader.html
 type RpcBlockHeader struct {


### PR DESCRIPTION
1. Use postgres dollar-n placeholders in queries. Also removed some unnecessary Prepare calls.
2. Postgres support detected by DB file-name prefix: "postgres://user:password@localhost/gigawallet"
3. Includes error handling for Postgres constraint violation and concurrent-transaction conflicts.

I had to make `dbErr` helper function a method of the Store so it can find out which backend we're using.

This meant changing every single call site!

But now we support both SQLite and Postgres backends. We probably should rename the store.
