### PR TITLE
Fix: no longer need decimal.RequireFromString

### DIFF
--- a/devconf.toml
+++ b/devconf.toml
@@ -8,7 +8,10 @@
   pubapirooturl = "http://localhost:8082"
 
 [Store]
-#  DBFile = "postgres://postgres:@localhost/gigawallet?sslmode=disable"
+#  SQLite: (default)
+#  DBFile = "gigawallet.db"
+#  Postgres:
+#  DBFile = "postgres://username:password@localhost/gigawallet?sslmode=disable"
 
 [gigawallet]
   network = "mainnet"  # which dogecoind to connect to

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -153,7 +153,7 @@ func (a API) CreateAccount(request AccountCreateRequest, foreignID string, upser
 			Address:         addr,
 			ForeignID:       foreignID,
 			PayoutAddress:   Address(request.PayoutAddress),
-			PayoutThreshold: decimal.RequireFromString(request.PayoutThreshold),
+			PayoutThreshold: request.PayoutThreshold,
 			PayoutFrequency: request.PayoutFrequency,
 			Privkey:         priv,
 		}


### PR DESCRIPTION
Changed Store config with examples
Fix: no longer need decimal.RequireFromString
