### PR TITLE
Multiple pay-to addresses

### DIFF
--- a/migrations/v0.1.1.sql
+++ b/migrations/v0.1.1.sql
@@ -1,0 +1,14 @@
+-- SQL Migration from v0.1.0-beta2 to v0.1.1
+
+ALTER TABLE payment DROP COLUMN pay_to;
+ALTER TABLE payment DROP COLUMN amount;
+ALTER TABLE payment ADD COLUMN total NUMERIC(18,8) NOT NULL;
+
+CREATE TABLE IF NOT EXISTS output (
+  payment_id INTEGER NOT NULL,
+  vout INTEGER NOT NULL,
+  pay_to TEXT NOT NULL,
+  amount NUMERIC(18,8) NOT NULL,
+  deduct_fee_percent NUMERIC(18,8) NOT NULL,
+  PRIMARY KEY (payment_id, vout)
+);

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -277,7 +277,7 @@ func (a API) SendFundsToAddress(foreignID string, explicitFee CoinAmount, payTo 
 			return
 		}
 	}
-	err = builder.CalculateFee(ZeroCoins)
+	err = builder.CalculateFee(explicitFee)
 	if err != nil {
 		return
 	}

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -251,25 +251,31 @@ func (a API) UpdateAccountSettings(foreignID string, update map[string]interface
 	return pub, nil
 }
 
-func (a API) SendFundsToAddress(foreignID string, amount CoinAmount, payTo Address) (txid string, fee CoinAmount, err error) {
+func (a API) SendFundsToAddress(foreignID string, explicitFee CoinAmount, payTo []PayTo) (txid string, fee CoinAmount, err error) {
 	account, err := a.Store.GetAccount(foreignID)
 	if err != nil {
 		return
 	}
-	if amount.LessThan(TxnDustLimit) {
-		return "", ZeroCoins, NewErr(BadRequest, "amount is too small - transaction will be rejected: %s", amount.String())
+	total := decimal.Zero
+	for _, pay := range payTo {
+		total = total.Add(pay.Amount)
+		if pay.Amount.LessThan(TxnDustLimit) {
+			return "", ZeroCoins, NewErr(BadRequest, "amount is less than dust limit - transaction will be rejected: %s pay to %s", pay.Amount.String(), pay.PayTo)
+		}
 	}
 	builder, err := NewTxnBuilder(&account, a.Store, a.L1)
 	if err != nil {
 		return
 	}
-	err = builder.AddUTXOsUpToAmount(amount)
+	err = builder.AddUTXOsUpToAmount(total)
 	if err != nil {
 		return
 	}
-	err = builder.AddOutput(payTo, amount)
-	if err != nil {
-		return
+	for _, pay := range payTo {
+		err = builder.AddOutput(pay.PayTo, pay.Amount)
+		if err != nil {
+			return
+		}
 	}
 	err = builder.CalculateFee(ZeroCoins)
 	if err != nil {
@@ -283,24 +289,24 @@ func (a API) SendFundsToAddress(foreignID string, amount CoinAmount, payTo Addre
 	// Create the Payment record up-front.
 	// Save changes to the Account (NextInternalKey) and address pool.
 	// Reserve the UTXOs for the payment.
-	tx, err := a.Store.Begin()
+	dbtx, err := a.Store.Begin()
 	if err != nil {
 		return
 	}
-	err = account.UpdatePoolAddresses(tx, a.L1) // we have used an address.
+	err = account.UpdatePoolAddresses(dbtx, a.L1) // we have used an address.
 	if err != nil {
-		tx.Rollback()
+		dbtx.Rollback()
 		return
 	}
-	err = tx.UpdateAccount(account) // for NextInternalKey (change address)
+	err = dbtx.UpdateAccount(account) // for NextInternalKey (change address)
 	if err != nil {
-		tx.Rollback()
+		dbtx.Rollback()
 		return
 	}
 	// Create the `payment` row with no txid or paid_height.
-	payment, err := tx.CreatePayment(account.Address, amount, payTo)
+	payment, err := dbtx.CreatePayment(account.Address, total, payTo)
 	if err != nil {
-		tx.Rollback()
+		dbtx.Rollback()
 		return
 	}
 	// err = tx.ReserveUTXOsForPayment(payId, builder.GetUTXOs()) // TODO
@@ -308,7 +314,7 @@ func (a API) SendFundsToAddress(foreignID string, amount CoinAmount, payTo Addre
 	//  tx.Rollback()
 	// 	return
 	// }
-	err = tx.Commit()
+	err = dbtx.Commit()
 	if err != nil {
 		return
 	}
@@ -321,16 +327,16 @@ func (a API) SendFundsToAddress(foreignID string, amount CoinAmount, payTo Addre
 
 	// Update the Payment with the txid,
 	// which changes it to "accepted" status (accepted by the network)
-	tx, err = a.Store.Begin()
+	dbtx, err = a.Store.Begin()
 	if err != nil {
 		return
 	}
-	err = tx.UpdatePaymentWithTxID(payment.ID, txid)
+	err = dbtx.UpdatePaymentWithTxID(payment.ID, txid)
 	if err != nil {
-		tx.Rollback()
+		dbtx.Rollback()
 		return
 	}
-	err = tx.Commit()
+	err = dbtx.Commit()
 	if err != nil {
 		return
 	}
@@ -340,7 +346,7 @@ func (a API) SendFundsToAddress(foreignID string, amount CoinAmount, payTo Addre
 		ForeignID: account.ForeignID,
 		AccountID: account.Address,
 		PayTo:     payTo,
-		Amount:    amount,
+		Total:     total,
 		TxID:      txid,
 	}
 	a.bus.Send(PAYMENT_SENT, msg)
@@ -360,7 +366,7 @@ func (a API) PayInvoiceFromAccount(invoiceID Address, foreignID string) (txid st
 	if invoiceAmount.LessThan(TxnDustLimit) {
 		return "", ZeroCoins, fmt.Errorf("invoice amount is too small - transaction will be rejected: %s", invoiceAmount.String())
 	}
-	payTo := invoice.ID // pay-to Address is the ID
+	payToAddress := invoice.ID // pay-to Address is the ID
 
 	// Make a Txn to pay `invoiceAmount` from `account` to `payTo`
 	builder, err := NewTxnBuilder(&account, a.Store, a.L1)
@@ -371,7 +377,7 @@ func (a API) PayInvoiceFromAccount(invoiceID Address, foreignID string) (txid st
 	if err != nil {
 		return
 	}
-	err = builder.AddOutput(payTo, invoiceAmount)
+	err = builder.AddOutput(payToAddress, invoiceAmount)
 	if err != nil {
 		return
 	}
@@ -383,11 +389,6 @@ func (a API) PayInvoiceFromAccount(invoiceID Address, foreignID string) (txid st
 	if err != nil {
 		return
 	}
-
-	// TODO: submit the transaction to Core.
-	// TODO: store back the account (to save NextInternalKey; also call UpdatePoolAddresses)
-	// TODO: somehow reserve the UTXOs in the interim (prevent accidental double-spend)
-	//       until ChainTracker sees the Txn in a Block and calls MarkUTXOSpent.
 
 	// Create the Payment record up-front.
 	// Save changes to the Account (NextInternalKey) and address pool.
@@ -407,6 +408,7 @@ func (a API) PayInvoiceFromAccount(invoiceID Address, foreignID string) (txid st
 		return
 	}
 	// Create the `payment` row with no txid or paid_height.
+	payTo := []PayTo{{Amount: invoiceAmount, PayTo: payToAddress}}
 	payment, err := tx.CreatePayment(account.Address, invoiceAmount, payTo)
 	if err != nil {
 		tx.Rollback()
@@ -449,7 +451,7 @@ func (a API) PayInvoiceFromAccount(invoiceID Address, foreignID string) (txid st
 		ForeignID: account.ForeignID,
 		AccountID: account.Address,
 		PayTo:     payTo,
-		Amount:    invoiceAmount,
+		Total:     invoiceAmount,
 		TxID:      txid,
 	}
 	a.bus.Send(PAYMENT_SENT, msg)

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -83,8 +83,8 @@ type PaymentEvent struct {
 	PaymentID int64      `json:"payment_id"`
 	AccountID Address    `json:"account_id"`
 	ForeignID string     `json:"foreign_id"`
-	PayTo     Address    `json:"pay_to"`
-	Amount    CoinAmount `json:"amount"`
+	PayTo     []PayTo    `json:"pay_to"`
+	Total     CoinAmount `json:"total"`
 	TxID      string     `json:"txid"`
 }
 

--- a/pkg/payment.go
+++ b/pkg/payment.go
@@ -1,12 +1,16 @@
 package giga
 
-import "time"
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
 
 type Payment struct {
 	ID               int64      // incrementing payment number, per account
 	AccountAddress   Address    // owner account (source of funds)
-	PayTo            Address    // a dogecoin address
-	Amount           CoinAmount // how much was paid
+	PayTo            []PayTo    // dogecoin addresses and amounts
+	Total            CoinAmount // total paid (excluding fees)
 	Created          time.Time  // when the payment was created
 	PaidTxID         string     // TXID of the Transaction that made the payment
 	PaidHeight       int64      // Block Height of the Transaction that made the payment
@@ -14,4 +18,12 @@ type Payment struct {
 	OnChainEvent     time.Time  // Time when the on-chain event was sent
 	ConfirmedEvent   time.Time  // Time when the confirmed event was sent
 	UnconfirmedEvent time.Time  // Time when the unconfirmed event was sent
+}
+
+// Pay an amount to an address
+// optional DeductFeePercent deducts a percentage of required fees from each PayTo (should sum to 100)
+type PayTo struct {
+	Amount           CoinAmount      `json:"amount"`
+	PayTo            Address         `json:"to"`
+	DeductFeePercent decimal.Decimal `json:"deduct_fee_percent"`
 }

--- a/pkg/services/balancekeeper.go
+++ b/pkg/services/balancekeeper.go
@@ -328,7 +328,7 @@ func (b BalanceKeeper) sendPaymentEvents(tx giga.StoreTransaction, acc *giga.Acc
 					ForeignID: acc.ForeignID,
 					AccountID: acc.Address,
 					PayTo:     pay.PayTo,
-					Amount:    pay.Amount,
+					Total:     pay.Total,
 					TxID:      pay.PaidTxID,
 				}
 				event := giga.PAYMENT_ON_CHAIN
@@ -351,7 +351,7 @@ func (b BalanceKeeper) sendPaymentEvents(tx giga.StoreTransaction, acc *giga.Acc
 					ForeignID: acc.ForeignID,
 					AccountID: acc.Address,
 					PayTo:     pay.PayTo,
-					Amount:    pay.Amount,
+					Total:     pay.Total,
 					TxID:      pay.PaidTxID,
 				}
 				event := giga.PAYMENT_CONFIRMED

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -97,7 +97,7 @@ type StoreTransaction interface {
 
 	// Store a 'payment' which represents a pay-out to another address from a gigawallet
 	// managed account.
-	CreatePayment(account Address, amount CoinAmount, payTo Address) (Payment, error)
+	CreatePayment(account Address, amount CoinAmount, payTo []PayTo) (Payment, error)
 
 	// GetPayment returns the Payment for the given ID
 	GetPayment(account Address, id int64) (Payment, error)


### PR DESCRIPTION
Accepts an array `pay` with multiple addresses and amounts, or `to` plus `amount` as before.
Optionally accepts `deduct_fee_percent` on each array item (0-100 decimal)

Also optionally accepts `explicit_fee` in the top-level request, to override fee calculations,
although the request will be rejected if the explicit_fee is less than the calculated minimum fee.

It needs some testing (next PR)

**Still to do:** actually deduct the percentages. Other features are done.