### PR TITLE
Store the fee paid in payment records, improve error messages

### DIFF
--- a/migrations/v0.1.1.sql
+++ b/migrations/v0.1.1.sql
@@ -1,9 +1,15 @@
 -- SQL Migration from v0.1.0-beta2 to v0.1.1
 
-ALTER TABLE payment DROP COLUMN pay_to;
-ALTER TABLE payment DROP COLUMN amount;
-ALTER TABLE payment ADD COLUMN total NUMERIC(18,8) NOT NULL;
+-- total is the sum of all payment outputs.
+-- since all existing payments had a single output, we can rename the old amount column.
+ALTER TABLE payment RENAME COLUMN amount TO total;
 
+-- we now store the fee paid by our transactions.
+-- since we can't infer this from the data we have, set existing rows to zero.
+ALTER TABLE payment ADD COLUMN fee NUMERIC(18,8) DEFAULT 0;
+ALTER TABLE payment ALTER COLUMN fee SET NOT NULL;
+
+-- create a table to hold multiple outputs for each payment.
 CREATE TABLE IF NOT EXISTS output (
   payment_id INTEGER NOT NULL,
   vout INTEGER NOT NULL,
@@ -12,3 +18,11 @@ CREATE TABLE IF NOT EXISTS output (
   deduct_fee_percent NUMERIC(18,8) NOT NULL,
   PRIMARY KEY (payment_id, vout)
 );
+
+-- copy existing pay_to and amount (now total) into the new outputs table.
+INSERT INTO output (payment_id, vout, pay_to, amount, deduct_fee_percent)
+SELECT payment_id, 0 as vout, pay_to, total as amount, 0 as deduct_fee_percent FROM payment;
+
+-- pay_to (and amount) were moved from payment table to output table.
+-- these fields no longer exist on the payment table.
+ALTER TABLE payment DROP COLUMN pay_to;

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -269,8 +269,8 @@ func (a API) SendFundsToAddress(foreignID string, explicitFee CoinAmount, payTo 
 	if err != nil {
 		return
 	}
-	total := newTxn.TotalOut
-	fee := newTxn.FeeAmount
+	total := newTxn.TotalOut // total paid to addresses (excludes fee)
+	fee := newTxn.FeeAmount  // fee paid by the transaction
 	txHex := newTxn.TxnHex
 
 	// Create the Payment record up-front.
@@ -291,7 +291,7 @@ func (a API) SendFundsToAddress(foreignID string, explicitFee CoinAmount, payTo 
 		return
 	}
 	// Create the `payment` row with no txid or paid_height.
-	payment, err := dbtx.CreatePayment(account.Address, total, payTo)
+	payment, err := dbtx.CreatePayment(account.Address, payTo, total, fee)
 	if err != nil {
 		dbtx.Rollback()
 		return
@@ -384,7 +384,7 @@ func (a API) PayInvoiceFromAccount(invoiceID Address, foreignID string) (res Sen
 		return
 	}
 	// Create the `payment` row with no txid or paid_height.
-	payment, err := tx.CreatePayment(account.Address, invoiceAmount, payTo)
+	payment, err := tx.CreatePayment(account.Address, payTo, invoiceAmount, fee)
 	if err != nil {
 		tx.Rollback()
 		return

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -42,9 +42,9 @@ var TxnDustLimit = OneCoin.Div(decimal.NewFromInt(100))       // 0.01 DOGE
 // A new transaction (hex) from libdogecoin.
 type NewTxn struct {
 	TxnHex       string     // Transaction in Hexadecimal format.
-	TotalIn      CoinAmount // Sum of all inputs (UTXOs)
-	TotalOut     CoinAmount // Sum of all outputs (NewTxOuts)
-	FeeAmount    CoinAmount // Calculated fee
+	TotalIn      CoinAmount // Sum of all inputs (UTXOs) spent by the transaction.
+	TotalOut     CoinAmount // Sum of all outputs (NewTxOuts) i.e. total amount paid (excludes fee)
+	FeeAmount    CoinAmount // Fee paid by the transaction
 	ChangeAmount CoinAmount // Change returned to wallet (excess input)
 }
 

--- a/pkg/payment.go
+++ b/pkg/payment.go
@@ -10,7 +10,8 @@ type Payment struct {
 	ID               int64      // incrementing payment number, per account
 	AccountAddress   Address    // owner account (source of funds)
 	PayTo            []PayTo    // dogecoin addresses and amounts
-	Total            CoinAmount // total paid (excluding fees)
+	Total            CoinAmount // total paid to others (excluding fees and change)
+	Fee              CoinAmount // fee paid by the transaction
 	Created          time.Time  // when the payment was created
 	PaidTxID         string     // TXID of the Transaction that made the payment
 	PaidHeight       int64      // Block Height of the Transaction that made the payment

--- a/pkg/store.go
+++ b/pkg/store.go
@@ -97,7 +97,7 @@ type StoreTransaction interface {
 
 	// Store a 'payment' which represents a pay-out to another address from a gigawallet
 	// managed account.
-	CreatePayment(account Address, amount CoinAmount, payTo []PayTo) (Payment, error)
+	CreatePayment(account Address, payTo []PayTo, total CoinAmount, fee CoinAmount) (Payment, error)
 
 	// GetPayment returns the Payment for the given ID
 	GetPayment(account Address, id int64) (Payment, error)

--- a/test/migration_test.go
+++ b/test/migration_test.go
@@ -1,0 +1,8 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestMigration_011(t *testing.T) {
+}


### PR DESCRIPTION
Store the calculated (or specified) fee in Payment records.

Improved error messages when calculating fees, deducting percentages, validating payment request.

Added store tests for creating, getting and listing Payments.

Re-wrote the migration script to migrate existing data, since that's mostly what a migration script is for.
This also fixes https://github.com/dogecoinfoundation/gigawallet/issues/123
