### PR TITLE
Use Core estimatesmartfee as a basis for fees (if available)

### DIFF
--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -173,12 +174,12 @@ type estimatesmartfeeResponse struct {
 
 func (l L1CoreRPC) EstimateFee(confirmTarget int) (feePerKB giga.CoinAmount, err error) {
 	var res estimatesmartfeeResponse
-	err = l.request("estimatesmartfee", []any{confirmTarget, "ECONOMICAL"}, &res)
+	err = l.request("estimatesmartfee", []any{confirmTarget}, &res)
 	if len(res.Errors) > 0 {
-		return giga.ZeroCoins, fmt.Errorf("estimatesmartfee: %s", res.Errors[0].Str)
+		return giga.ZeroCoins, errors.New(res.Errors[0].Str)
 	}
 	if res.FeeRate < 0 {
-		return giga.ZeroCoins, fmt.Errorf("estimatesmartfee: no fee-rate available")
+		return giga.ZeroCoins, errors.New("fee-rate is negative")
 	}
 	feePerKB = decimal.NewFromInt(res.FeeRate)
 	return

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -10,6 +10,7 @@ import (
 
 	giga "github.com/dogecoinfoundation/gigawallet/pkg"
 	"github.com/dogecoinfoundation/gigawallet/pkg/doge"
+	"github.com/shopspring/decimal"
 )
 
 // interface guard ensures L1CoreRPC implements giga.L1
@@ -158,5 +159,27 @@ func (l L1CoreRPC) Send(txnHex string) (txid string, err error) {
 	if txid != hash {
 		log.Printf("[!] sendrawtransaction: did not return the expected txid: %s vs %s", txid, hash)
 	}
+	return
+}
+
+type estimatesmartfeeError struct {
+	Str string `json:"str"`
+}
+type estimatesmartfeeResponse struct {
+	FeeRate int64                   `json:"feerate"`
+	Blocks  int64                   `json:"blocks"`
+	Errors  []estimatesmartfeeError `json:"errors"`
+}
+
+func (l L1CoreRPC) EstimateFee(confirmTarget int) (feePerKB giga.CoinAmount, err error) {
+	var res estimatesmartfeeResponse
+	err = l.request("estimatesmartfee", []any{confirmTarget, "ECONOMICAL"}, &res)
+	if len(res.Errors) > 0 {
+		return giga.ZeroCoins, fmt.Errorf("estimatesmartfee: %s", res.Errors[0].Str)
+	}
+	if res.FeeRate < 0 {
+		return giga.ZeroCoins, fmt.Errorf("estimatesmartfee: no fee-rate available")
+	}
+	feePerKB = decimal.NewFromInt(res.FeeRate)
 	return
 }

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -26,6 +26,7 @@ type L1 interface {
 	GetBlockCount() (int64, error)
 	GetTransaction(txnHash string) (RawTxn, error)
 	Send(txnHex string) (txid string, err error)
+	EstimateFee(confirmTarget int) (feePerKB CoinAmount, err error)
 	//SignMessage([]byte, Privkey) (string, error)
 }
 

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -34,12 +34,13 @@ type Address string // Dogecoin address (base-58 public key hash aka PKH)
 type Privkey string // Extended Private Key for HD Wallet
 type CoinAmount = decimal.Decimal
 
-var ZeroCoins = decimal.NewFromInt(0)                         // 0 DOGE
-var OneCoin = decimal.NewFromInt(1)                           // 1.0 DOGE
-var TxnMinFee = OneCoin.Div(decimal.NewFromInt(100))          // 0.01 DOGE (RECOMMENDED_MIN_TX_FEE in Core)
-var TxnFeePerKB = OneCoin.Div(decimal.NewFromInt(100))        // 0.01 DOGE
-var TxnFeePerByte = TxnFeePerKB.Div(decimal.NewFromInt(1000)) // since Core version 1.14.5
-var TxnDustLimit = OneCoin.Div(decimal.NewFromInt(100))       // 0.01 DOGE
+var ZeroCoins = decimal.NewFromInt(0)                           // 0 DOGE
+var OneCoin = decimal.NewFromInt(1)                             // 1.0 DOGE
+var TxnRecommendedMinFee = OneCoin.Div(decimal.NewFromInt(100)) // 0.01 DOGE (RECOMMENDED_MIN_TX_FEE in Core)
+var TxnRecommendedMaxFee = OneCoin                              // 1 DOGE
+var TxnFeePerKB = OneCoin.Div(decimal.NewFromInt(100))          // 0.01 DOGE
+var TxnFeePerByte = TxnFeePerKB.Div(decimal.NewFromInt(1000))   // since Core version 1.14.5
+var TxnDustLimit = OneCoin.Div(decimal.NewFromInt(100))         // 0.01 DOGE
 
 // A new transaction (hex) from libdogecoin.
 type NewTxn struct {

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -35,6 +35,7 @@ type CoinAmount = decimal.Decimal
 
 var ZeroCoins = decimal.NewFromInt(0)                         // 0 DOGE
 var OneCoin = decimal.NewFromInt(1)                           // 1.0 DOGE
+var TxnMinFee = OneCoin.Div(decimal.NewFromInt(100))          // 0.01 DOGE (RECOMMENDED_MIN_TX_FEE in Core)
 var TxnFeePerKB = OneCoin.Div(decimal.NewFromInt(100))        // 0.01 DOGE
 var TxnFeePerByte = TxnFeePerKB.Div(decimal.NewFromInt(1000)) // since Core version 1.14.5
 var TxnDustLimit = OneCoin.Div(decimal.NewFromInt(100))       // 0.01 DOGE

--- a/pkg/dogecoin/libdogecoin.go
+++ b/pkg/dogecoin/libdogecoin.go
@@ -219,3 +219,10 @@ func (l L1Libdogecoin) Send(txnHex string) (txid string, err error) {
 	}
 	return "", fmt.Errorf("not implemented")
 }
+
+func (l L1Libdogecoin) EstimateFee(confirmTarget int) (feePerKB giga.CoinAmount, err error) {
+	if l.fallback != nil {
+		return l.fallback.EstimateFee(confirmTarget)
+	}
+	return giga.ZeroCoins, fmt.Errorf("not implemented")
+}

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -62,5 +62,5 @@ func (l L1Mock) Send(txnHex string) (txid string, err error) {
 }
 
 func (l L1Mock) EstimateFee(confirmTarget int) (feePerKB giga.CoinAmount, err error) {
-	return decimal.NewFromString("1.0")
+	return decimal.NewFromString("0.67891013") // example from Core
 }

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	giga "github.com/dogecoinfoundation/gigawallet/pkg"
+	"github.com/shopspring/decimal"
 )
 
 // interface guard ensures L1Mock implements giga.L1
@@ -58,4 +59,8 @@ func (l L1Mock) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
 
 func (l L1Mock) Send(txnHex string) (txid string, err error) {
 	return "FEED000000000000000000000000000000000000000000000000000000000000", nil
+}
+
+func (l L1Mock) EstimateFee(confirmTarget int) (feePerKB giga.CoinAmount, err error) {
+	return decimal.NewFromString("1.0")
 }

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -889,10 +889,9 @@ func (t SQLiteStoreTransaction) MarkInvoiceEventSent(invoiceID giga.Address, eve
 
 // Prepare query for MarkInvoicesPaid.
 // Summing all UTXOs that payTo the Invoice Address that have been confirmed (spendable_height is non-null)
-// ConfirmUTXOs sets spendable_height when the UTXO has N confirmations, where N comes from the Invoice!
 var sum_utxos_for_invoice = "SELECT SUM(value) FROM utxo WHERE script_address=i.invoice_address AND spendable_height IS NOT NULL"
-var invoices_above_total = fmt.Sprintf("SELECT invoice_address FROM invoice i WHERE (%s) >= total", sum_utxos_for_invoice)
-var mark_invoices_paid = fmt.Sprintf("UPDATE invoice SET paid_height=$1, block_id=$2 WHERE invoice_address IN (%s) RETURNING account_address", invoices_above_total)
+var unpaid_invoices_above_total = fmt.Sprintf("SELECT invoice_address FROM invoice i WHERE paid_height IS NULL AND (%s) >= total", sum_utxos_for_invoice)
+var mark_invoices_paid = fmt.Sprintf("UPDATE invoice SET paid_height=$1, block_id=$2 WHERE invoice_address IN (%s) RETURNING account_address", unpaid_invoices_above_total)
 
 // Mark all invoices paid that have corresponding confirmed UTXOs [via ConfirmUTXOs]
 // that sum up to the invoice total, storing the given block-height. Returns the IDs

--- a/pkg/txn.go
+++ b/pkg/txn.go
@@ -154,6 +154,9 @@ func subtractFeeFromOutput(output int, fee decimal.Decimal, feePercent decimal.D
 func feeForSize(txHex string) CoinAmount {
 	numBytes := decimal.NewFromInt(int64(len(txHex) / 2))
 	fee := TxnFeePerByte.Mul(numBytes)
+	if fee.LessThan(TxnMinFee) {
+		fee = TxnMinFee
+	}
 	return fee
 }
 

--- a/pkg/webapi/webapi.go
+++ b/pkg/webapi/webapi.go
@@ -334,7 +334,8 @@ type ListInvoicesPublicResponse struct {
 type PayToAddressRequest struct {
 	Amount      giga.CoinAmount `json:"amount"`
 	PayTo       giga.Address    `json:"to"`
-	ExplicitFee giga.CoinAmount `json:"explicit_fee"` // optional fee amount
+	ExplicitFee giga.CoinAmount `json:"explicit_fee"` // optional fee override (missing or zero: calculate the fee)
+	MaxFee      giga.CoinAmount `json:"max_fee"`      // optional maximum fee (missing or zero: maximum is 1 DOGE)
 	Pay         []giga.PayTo    `json:"pay"`          // either Pay, or Amount and PayTo.
 }
 
@@ -357,10 +358,10 @@ func (t WebAPI) payToAddress(w http.ResponseWriter, r *http.Request, p httproute
 		return
 	}
 	if len(o.Pay) == 0 {
-		// treat the request as an array of one item.
+		// treat 'PayTo' request as an array of one item.
 		o.Pay = append(o.Pay, giga.PayTo{Amount: o.Amount, PayTo: o.PayTo})
 	}
-	res, err := t.api.SendFundsToAddress(foreignID, o.ExplicitFee, o.Pay)
+	res, err := t.api.SendFundsToAddress(foreignID, o.Pay, o.ExplicitFee, o.MaxFee)
 	if err != nil {
 		sendError(w, "SendFundsToAddress", err)
 		return

--- a/pkg/webapi/webapi_test.go
+++ b/pkg/webapi/webapi_test.go
@@ -103,17 +103,17 @@ func TestWebAPI(t *testing.T) {
 	}
 
 	// Pay to Multiple Addresses with percentage split
-	request(t, admin, "/account/Pepper/pay", `{"pay":[{"amount":"2","to":"`+to_1+`","deduct_fee_percent":"80"},{"amount":"1","to":"`+to_2+`","deduct_fee_percent":"20"}]}`, &payTo)
+	request(t, admin, "/account/Pepper/pay", `{"pay":[{"amount":"2","to":"`+to_1+`","deduct_fee_percent":"80"},{"amount":"1","to":"`+to_2+`","deduct_fee_percent":"20"}],"explicit_fee":"0.1"}`, &payTo)
 	if payTo.TxId == "" {
 		t.Fatalf("Pay To Address 3: missing txid")
 	}
 	if !payTo.Total.Equals(decimal.RequireFromString("3")) {
 		t.Fatalf("Pay To Address 3: wrong total: %v", payTo.Total)
 	}
-	if !payTo.Fee.GreaterThanOrEqual(decimal.RequireFromString("0.00259")) {
+	if !payTo.Fee.Equals(decimal.RequireFromString("0.1")) {
 		t.Fatalf("Pay To Address 3: wrong fee: %v", payTo.Fee)
 	}
-	if !payTo.Paid.GreaterThanOrEqual(decimal.RequireFromString("2.9974")) {
+	if !payTo.Paid.Equals(decimal.RequireFromString("2.9")) {
 		t.Fatalf("Pay To Address 3: wrong paid: %v", payTo.Paid)
 	}
 }

--- a/test/newtxn_test.go
+++ b/test/newtxn_test.go
@@ -36,7 +36,7 @@ func TestNewTxn(t *testing.T) {
 			{Amount: dc("1"), PayTo: to_2, DeductFeePercent: dc("20")},
 		}
 		source := giga.NewArrayUTXOSource(testUTXOs)
-		txn, err := giga.CreateTxn(payTo, giga.ZeroCoins, acc, source, lib)
+		txn, err := giga.CreateTxn(payTo, giga.ZeroCoins, giga.OneCoin, acc, source, lib)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -52,6 +52,7 @@ func TestNewTxn(t *testing.T) {
 		if !txn.TotalOut.Equals(decimal.RequireFromString("3").Sub(txn.FeeAmount)) {
 			t.Fatalf("wrong total outputs: %v", txn.TotalOut)
 		}
+		t.Logf("DeductFeePercent: %v In => %v Out + %v Fee = %v + Change %v", txn.TotalIn, txn.TotalOut, txn.FeeAmount, txn.TotalOut.Add(txn.FeeAmount), txn.ChangeAmount)
 	})
 }
 


### PR DESCRIPTION
Note: after Core is restarted, estimatesmartfee takes a while to start working!

Always use a minimum fee of 0.01 DOGE
Allow a maximum fee to be specified, by default use maximum 1 DOGE

Fix: only mark unpaid invoices paid (fixes duplicate data)
