### PR TITLE
Fix: use documented API for invoice creation (REST convention)

### DIFF
--- a/pkg/webapi/webapi.go
+++ b/pkg/webapi/webapi.go
@@ -75,8 +75,9 @@ func (t WebAPI) createRouters() (adminMux *httprouter.Router, pubMux *httprouter
 	// GET /account:foreignID/Balance -> { AccountBalance    Get the account balance
 	adminMux.GET("/account/:foreignID/balance", t.getAccountBalance)
 
-	// POST {invoice} /account/:foreignID/invoice/ -> { invoice } create new invoice
-	adminMux.POST("/account/:foreignID/invoice/", t.createInvoice)
+	// POST {invoice} /account/:foreignID/invoice -> { invoice } create new invoice
+	adminMux.POST("/account/:foreignID/invoice", t.createInvoice)  // intended API
+	adminMux.POST("/account/:foreignID/invoice/", t.createInvoice) // deprecated: prior bug
 
 	// GET /account/:foreignID/invoices ? args -> [ {...}, ..] get all / filtered invoices
 	adminMux.GET("/account/:foreignID/invoices", t.listInvoices)

--- a/pkg/webapi/webapi_test.go
+++ b/pkg/webapi/webapi_test.go
@@ -48,7 +48,7 @@ func TestWebAPI(t *testing.T) {
 
 	// Create an Invoice for 10 doge
 	var inv1 giga.PublicInvoice
-	request(t, admin, "/account/Pepper/invoice/", `{"items":[{"type":"item","name":"Pants","sku":"P-001","description":"Nice pants","value":"10","quantity":1}],"confirmations":6}`, &inv1)
+	request(t, admin, "/account/Pepper/invoice", `{"items":[{"type":"item","name":"Pants","sku":"P-001","description":"Nice pants","value":"10","quantity":1}],"confirmations":6}`, &inv1)
 	if !doge.ValidateP2PKH(string(inv1.ID), &doge.DogeTestNetChain) {
 		t.Fatalf("Create Invoice generated an invalid Address: %v", inv1.ID)
 	}


### PR DESCRIPTION
Now accepts: POST /account/:foreignID/invoice

Previously the router had an accidental slash on the end.