### PR TITLE
Added deprecated invoice API for backwards compatibility, fix test.

### DIFF
--- a/pkg/webapi/webapi.go
+++ b/pkg/webapi/webapi.go
@@ -77,6 +77,7 @@ func (t WebAPI) createRouters() (adminMux *httprouter.Router, pubMux *httprouter
 
 	// POST {invoice} /account/:foreignID/invoice -> { invoice } create new invoice
 	adminMux.POST("/account/:foreignID/invoice", t.createInvoice)
+	adminMux.POST("/account/:foreignID/invoice/", t.createInvoice) // deprecated: prior bug
 
 	// GET /account/:foreignID/invoices ? args -> [ {...}, ..] get all / filtered invoices
 	adminMux.GET("/account/:foreignID/invoices", t.listInvoices)

--- a/pkg/webapi/webapi_test.go
+++ b/pkg/webapi/webapi_test.go
@@ -48,7 +48,7 @@ func TestWebAPI(t *testing.T) {
 
 	// Create an Invoice for 10 doge
 	var inv1 giga.PublicInvoice
-	request(t, admin, "/account/Pepper/invoice/", `{"items":[{"type":"item","name":"Pants","sku":"P-001","description":"Nice pants","value":"10","quantity":1}],"confirmations":6}`, &inv1)
+	request(t, admin, "/account/Pepper/invoice", `{"items":[{"type":"item","name":"Pants","sku":"P-001","description":"Nice pants","value":"10","quantity":1}],"confirmations":6}`, &inv1)
 	if !doge.ValidateP2PKH(string(inv1.ID), &doge.DogeTestNetChain) {
 		t.Fatalf("Create Invoice generated an invalid Address: %v", inv1.ID)
 	}


### PR DESCRIPTION
Subsequent to PR #129 which removed the slash from the create invoice API. Anyone already using Gigawallet @qlpqlp will be affected by the change, so this PR adds a deprecated API.

It also fixes the webapi test that creates an invoice.
