### PR TITLE
Fix: round inputs and fee calcs to nearest Koinu (8 digits)

### DIFF
--- a/pkg/doge/block.go
+++ b/pkg/doge/block.go
@@ -105,6 +105,11 @@ func readMerkleBranch(s *Stream) (b MerkleBranch) {
 	return
 }
 
+func DecodeTx(txBytes []byte) BlockTx {
+	s := &Stream{b: txBytes}
+	return readTx(s)
+}
+
 func readTx(s *Stream) (tx BlockTx) {
 	start := s.p
 	tx.Version = s.uint32le()

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -37,6 +37,10 @@ type Privkey string         // Extended Private Key for HD Wallet
 type CoinAmount = decimal.Decimal
 type ScriptType = doge.ScriptType
 
+const OneCoin_64 = 100_000_000           // 1 DOGE
+const TxnDustLimit_64 = OneCoin_64 / 100 // 0.01 DOGE
+const NumKoinuDigits = 8                 // Maximum Koinu digits (after decimal point)
+
 var ZeroCoins = decimal.NewFromInt(0)                           // 0 DOGE
 var OneCoin = decimal.NewFromInt(1)                             // 1.0 DOGE
 var TxnRecommendedMinFee = OneCoin.Div(decimal.NewFromInt(100)) // 0.01 DOGE (RECOMMENDED_MIN_TX_FEE in Core)


### PR DESCRIPTION
This fixes a problem where we were creating transactions with a change output of 0.00000001 doge, well under the dust limit, due to rounding errors in the fee calculation. (Can also happen when floating point values are passed to the web api, so those are now rounded too.)
