### PR TITLE
Wait for Initial Block Download in core

### DIFF
--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -71,6 +71,10 @@ func (l *L1CoreRPC) request(method string, params []any, result any) error {
 	if err != nil {
 		return fmt.Errorf("json-rpc read response: %v", err)
 	}
+	// check for error response
+	if res.StatusCode != 200 {
+		return fmt.Errorf("json-rpc error status: %v", res.StatusCode)
+	}
 	// cannot use json.NewDecoder: "The decoder introduces its own buffering
 	// and may read data from r beyond the JSON values requested."
 	var rpcres rpcResponse
@@ -146,6 +150,11 @@ func (l *L1CoreRPC) GetBestBlockHash() (blockHash string, err error) {
 
 func (l *L1CoreRPC) GetBlockCount() (blockCount int64, err error) {
 	err = l.request("getblockcount", []any{}, &blockCount)
+	return
+}
+
+func (l *L1CoreRPC) GetBlockchainInfo() (info giga.RpcBlockchainInfo, err error) {
+	err = l.request("getblockchaininfo", []any{}, &info)
 	return
 }
 

--- a/pkg/dogecoin.go
+++ b/pkg/dogecoin.go
@@ -26,6 +26,7 @@ type L1 interface {
 	GetBlockHash(height int64) (string, error)
 	GetBestBlockHash() (string, error)
 	GetBlockCount() (int64, error)
+	GetBlockchainInfo() (RpcBlockchainInfo, error)
 	GetTransaction(txnHash string) (RawTxn, error)
 	Send(txnHex string) (txid string, err error)
 	EstimateFee(confirmTarget int) (feePerKB CoinAmount, err error)
@@ -170,4 +171,23 @@ type RpcBlockHeader struct {
 	ChainWork         string          `json:"chainwork"`         // (string) Expected number of hashes required to produce the chain up to this block (hex)
 	PreviousBlockHash string          `json:"previousblockhash"` // (string) The hash of the previous block (hex)
 	NextBlockHash     string          `json:"nextblockhash"`     // (string) The hash of the next block (hex)
+}
+
+// RpcBlockchainInfo from Core
+type RpcBlockchainInfo struct {
+	Chain                string  `json:"chain"`                // (string) current network name (main, test, regtest)
+	Blocks               int64   `json:"blocks"`               // (numeric) the height of the most-work fully-validated chain. The genesis block has height 0
+	Headers              int64   `json:"headers"`              // (numeric) the current number of headers we have validated
+	BestBlockHash        string  `json:"bestblockhash"`        // (string) the hash of the currently best block
+	Difficulty           float64 `json:"difficulty"`           // (numeric) the current difficulty
+	MedianTime           int64   `json:"mediantime"`           // (numeric) median time for the current best block
+	VerificationProgress float64 `json:"verificationprogress"` // (numeric) estimate of verification progress [0..1]
+	InitialBlockDownload bool    `json:"initialblockdownload"` // (boolean) (debug information) estimate of whether this node is in Initial Block Download mode
+	ChainWord            string  `json:"chainwork"`            // (string) total amount of work in active chain, in hexadecimal
+	SizeOnDisk           int64   `json:"size_on_disk"`         // (numeric) the estimated size of the block and undo files on disk
+	Pruned               bool    `json:"pruned"`               // (boolean) if the blocks are subject to pruning
+	PruneHeight          int64   `json:"pruneheight"`          // (numeric) lowest-height complete block stored (only present if pruning is enabled)
+	AutomaticPruning     bool    `json:"automatic_pruning"`    // (boolean) whether automatic pruning is enabled (only present if pruning is enabled)
+	PruneTargetSize      int64   `json:"prune_target_size"`    // (numeric) the target size used by pruning (only present if automatic pruning is enabled)
+
 }

--- a/pkg/dogecoin/libdogecoin.go
+++ b/pkg/dogecoin/libdogecoin.go
@@ -213,6 +213,13 @@ func (l L1Libdogecoin) GetBlockCount() (blockCount int64, err error) {
 	return 0, fmt.Errorf("not implemented")
 }
 
+func (l L1Libdogecoin) GetBlockchainInfo() (info giga.RpcBlockchainInfo, err error) {
+	if l.fallback != nil {
+		return l.fallback.GetBlockchainInfo()
+	}
+	return giga.RpcBlockchainInfo{}, fmt.Errorf("not implemented")
+}
+
 func (l L1Libdogecoin) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
 	if l.fallback != nil {
 		return l.fallback.GetTransaction(txnHash)

--- a/pkg/dogecoin/mock.go
+++ b/pkg/dogecoin/mock.go
@@ -57,6 +57,10 @@ func (l L1Mock) GetBlockCount() (blockCount int64, err error) {
 	return 100, nil
 }
 
+func (l L1Mock) GetBlockchainInfo() (info giga.RpcBlockchainInfo, err error) {
+	return giga.RpcBlockchainInfo{}, fmt.Errorf("not implemented")
+}
+
 func (l L1Mock) GetTransaction(txnHash string) (txn giga.RawTxn, err error) {
 	return giga.RawTxn{}, nil
 }


### PR DESCRIPTION
This avoids a problem where we get the current block height too early and end up following the entire blockchain.