### PR TITLE
Sign webhooks with optional HMAC

### DIFF
--- a/devconf.toml
+++ b/devconf.toml
@@ -28,8 +28,8 @@
   zmqport = 28332
   rpchost = "127.0.0.1"
   rpcport = 22555
-  rpcpass = "suchpay"
-  rpcuser = "suchpay"
+  rpcpass = "gigawallet"
+  rpcuser = "gigawallet"
 
 ## Setup loggers, see pkg/config.go LoggersConfig
 [loggers.events]
@@ -41,6 +41,8 @@
 #[callbacks.example1]
 #  path = "https://example.com/invoiceEvents"
 #  types = ["INV"]
+#  # Optional: Add HMAC secret for request signing
+#  # hmacsecret = "your-secret-key-here"
 
 
 ## Setup MQTT event publishing, see pkg/config.go MQTTConfig

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -79,8 +79,9 @@ type LoggersConfig struct {
 }
 
 type CallbackConfig struct {
-	Path  string
-	Types []string
+	Path       string
+	Types      []string
+	HMACSecret string
 }
 
 type MQTTConfig struct {


### PR DESCRIPTION
This allows signing outbound webhooks/callbacks with a HMAC signature so services can authenticate inbound requests from Gigawallet.

Sets both `X-Giga-Signature` and `X-Giga-Timestamp`.